### PR TITLE
influxdb-python requires at least requests>=2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 six
-requests
+requests>=1.0.3


### PR DESCRIPTION
when using response.json() api
