### PR TITLE
Use params option of Requests, urlencode is useless

### DIFF
--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -4,8 +4,6 @@ python client for influxdb
 """
 import json
 
-from six.moves.urllib.parse import urlencode
-
 import requests
 session = requests.Session()
 
@@ -159,20 +157,22 @@ class InfluxDBClient(object):
         else:
             chunked_param = 'false'
 
-        encoded_query = urlencode({
-            'q': query})
+        url = "{0}/db/{1}/series"
 
-        url_format = "{0}/db/{1}/series?{2}&u={3}&p={4}"
-        url_format += "&time_precision={5}&chunked={6}"
-
-        response = session.get(url_format.format(
+        url.format(
             self._baseurl,
-            self._database,
-            encoded_query,
-            self._username,
-            self._password,
-            time_precision,
-            chunked_param))
+            self._database
+        )
+
+        params = {
+            'u': self._username,
+            'p': self._password,
+            'q': query,
+            'time_precision': time_precision,
+            'chunked': chunked_param
+        }
+
+        response = session.get(url, params=params)
 
         if response.status_code == 200:
             return json.loads(response.content)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-six
 requests>=1.0.3


### PR DESCRIPTION
See (https://github.com/influxdb/influxdb-python/issues/6). I haven't tested on real DB, someone can test before merge ?

If ok, next step: change all url forging (`...?u={2}&p={3}...`) in the code ;)
