### PR TITLE
Add: HTTPS support with 'ssl' flag

### DIFF
--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -14,7 +14,7 @@ class InfluxDBClient(object):
     """
 
     def __init__(self, host='localhost', port=8086, username='root',
-                 password='root', database=None):
+                 password='root', database=None, ssl=False):
         """
         Initialize client
         """
@@ -23,7 +23,15 @@ class InfluxDBClient(object):
         self._username = username
         self._password = password
         self._database = database
-        self._baseurl = "http://{0}:{1}".format(self._host, self._port)
+        self._scheme = "http"
+
+        if ssl is True:
+            self._scheme = "https"
+
+        self._baseurl = "{0}://{1}:{2}".format(
+            self._scheme,
+            self._host,
+            self._port)
 
         self._headers = {
             'Content-type': 'application/json',

--- a/tests/influxdb/client_test.py
+++ b/tests/influxdb/client_test.py
@@ -18,6 +18,13 @@ def _build_response_object(status_code=200, content=""):
 
 
 class TestInfluxDBClient(object):
+    def test_scheme(self):
+        cli = InfluxDBClient('host', 8086, 'username', 'password', 'database')
+        assert cli._baseurl == 'http://host:8086'
+
+        cli = InfluxDBClient('host', 8086, 'username', 'password', 'database', ssl=True)
+        assert cli._baseurl == 'https://host:8086'
+
     def test_switch_db(self):
         cli = InfluxDBClient('host', 8086, 'username', 'password', 'database')
         cli.switch_db('another_database')


### PR DESCRIPTION
Use `ssl=True` on `init` to enable HTTPS.
Someone can test in real situation ?

See #22
