### PR TITLE
Fix: flake8 tests

### DIFF
--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -62,7 +62,7 @@ class InfluxDBClient(object):
     def write_points(self, *args, **kwargs):
         """
         Write to multiple time series names
-        
+
         Parameters
         ----------
         batch_size : Optional. Int value to write the points in batches instead
@@ -83,14 +83,18 @@ class InfluxDBClient(object):
                 name = data.get('name')
                 columns = data.get('columns')
                 point_list = data.get('points')
-                total_batches = len(point_list) * 1.0/batch_size
+
                 for batch in list_chunks(point_list, batch_size):
-                    data = [{"points": batch,
-                         "name": name,
-                         "columns": columns}]
+                    data = [{
+                        "points": batch,
+                        "name": name,
+                        "columns": columns
+                    }]
                     time_precision = kwargs.get('time_precision', 's')
-                    self.write_points_with_precision(data=data,
+                    self.write_points_with_precision(
+                        data=data,
                         time_precision=time_precision)
+
                 return True
 
         return self.write_points_with_precision(*args, **kwargs)


### PR DESCRIPTION
```
flake8 runtests: commands[0] | flake8 influxdb
influxdb/client.py:73:1: W293 blank line contains whitespace
influxdb/client.py:94:17: F841 local variable 'total_batches' is assigned to but never used
influxdb/client.py:97:26: E128 continuation line under-indented for visual indent
influxdb/client.py:98:26: E128 continuation line under-indented for visual indent
influxdb/client.py:101:25: E128 continuation line under-indented for visual indent
ERROR: InvocationError: '......./gits/influxdb-python/.tox/flake8/bin/flake8 influxdb'
```
