### PR TITLE
add the status code in the Request exception

### DIFF
--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -96,8 +96,8 @@ class InfluxDBClient(object):
         if response.status_code == status_code:
             return response
         else:
-            raise Exception(
-                "{0}: {1}".format(response.status_code, response.content))
+            raise Exception({"code": response.status_code,
+                "message": "{0}: {1}".format(response.status_code, response.content)})
 
     # Writing Data
     #


### PR DESCRIPTION
This will give something similar to an HTTPError, including code and message instead of just message.
It will make it easier to parse the exception, for example when trying to create a database that already exists.

FYI, messages and codes are defined in Influxdb as :

func errorToStatusCode(err error) int {
        switch err.(type) {
        case AuthenticationError:
                return libhttp.StatusUnauthorized // HTTP 401
        case AuthorizationError:
                return libhttp.StatusForbidden // HTTP 403
        case DatabaseExistsError:
                return libhttp.StatusConflict // HTTP 409
        default:
                return libhttp.StatusBadRequest // HTTP 400
        }
}
