### PR TITLE
add the status code in the Request exception

### DIFF
--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -8,9 +8,11 @@ import requests
 session = requests.Session()
 
 class InfluxDBClientError(Exception):
-    "Raised when an error occures in Influxdb Client"
-    pass
-
+    "Raised when an error occures in the Request"
+    def __init__(self, message, code):
+      self.message = message
+      self.code = code
+      
 class InfluxDBClient(object):
     """
     InfluxDB Client
@@ -100,9 +102,7 @@ class InfluxDBClient(object):
             return response
             
         else:
-            error = InfluxDBClientError()
-            error.message = "{0}: {1}".format(response.status_code, response.content)
-            error.code = response.status_code
+            error = InfluxDBClientError("{0}: {1}".format(response.status_code, response.content), response.status_code)
             raise error
 
     # Writing Data


### PR DESCRIPTION
Create a InfluxDBClientError class as Exception
This will allow something similar to an HTTPError, including code and message instead of just message.
It will make it easier to parse the exception, for example when trying to create a database that already exists.
This may be a breaking change for some if they already parse the message.

FYI, messages and codes are defined in Influxdb as :

func errorToStatusCode(err error) int {
switch err.(type) {
case AuthenticationError:
return libhttp.StatusUnauthorized // HTTP 401
case AuthorizationError:
return libhttp.StatusForbidden // HTTP 403
case DatabaseExistsError:
return libhttp.StatusConflict // HTTP 409
default:
return libhttp.StatusBadRequest // HTTP 400
}
}
