### PR TITLE
Added optional read timeout.

### DIFF
--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -14,7 +14,7 @@ class InfluxDBClient(object):
     """
 
     def __init__(self, host='localhost', port=8086, username='root',
-                 password='root', database=None, ssl=False, verify_ssl=False):
+                 password='root', database=None, ssl=False, verify_ssl=False, timeout=0):
         """
         Initialize client
         """
@@ -23,6 +23,7 @@ class InfluxDBClient(object):
         self._username = username
         self._password = password
         self._database = database
+        self._timeout = timeout
 
         self._verify_ssl = verify_ssl
 
@@ -90,7 +91,8 @@ class InfluxDBClient(object):
             params=params,
             data=data,
             headers=self._headers,
-            verify=self._verify_ssl
+            verify=self._verify_ssl,
+            timeout=self._timeout
             )
 
         if response.status_code == status_code:


### PR DESCRIPTION
Defaults to no timeout.

From requests documentation "timeout is not a time limit on the entire response download; rather, an exception is raised if the server has not issued a response for timeout seconds (more precisely, if no bytes have been received on the underlying socket for timeout seconds)."

I have seen cases where a write_points would stall and never return, locking up my client script until it is detected and restarted. This timeout should hopefully allow this to be quicker detected and also help determine the root cause (why the connection is stalling to InfluxDB running on localhost). I am sure a timeout is useful to other people than me using the library, hence the PR.
