### PR TITLE
Must decode json in python 3 . Assume default utf8 encoding.

### DIFF
--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -255,7 +255,13 @@ class InfluxDBClient(object):
             status_code=200
             )
 
-        return json.loads(response.content)
+        try:
+            res = json.loads(response.content)
+        except TypeError:
+            # must decode in python 3 
+            res = json.loads(response.content.decode('utf8'))
+
+        return res
 
     # Creating and Dropping Databases
     #


### PR DESCRIPTION
This fixes an error I was getting in Python 3.4:

`*** TypeError: the JSON object must be str, not 'bytes'`

By decoding the json returned, seems to fix the issue:

```
-> return json.loads(response.content)
(Pdb) response.content
b'[{"name":"p_nodes_avail","columns":["time","sequence_number","active"],"points":[[1402002269,100001,1391],[1402001816,90001,1391],[1402001338,80001,1391],[1402000896,70001,1391],[1402000386,60001,1391],[1402000364,50001,1391]]}]'
(Pdb) json.loads(response.content)
*** TypeError: the JSON object must be str, not 'bytes'
(Pdb) json.loads(response.content.decode('utf8'))
[{'points': [[1402002269, 100001, 1391], [1402001816, 90001, 1391], [1402001338, 80001, 1391], [1402000896, 70001, 1391], [1402000386, 60001, 1391], [1402000364, 50001, 1391]], 'columns': ['time', 'sequence_number', 'active'], 'name': 'p_nodes_avail'}]
```

Let me know if this works for you.

Thanks!
   Kurt
