### PR TITLE
Query with chucks works with 1 series of data. 

### DIFF
--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -282,11 +282,14 @@ class InfluxDBClient(object):
             status_code=200
             )
 
-        try:
-            res = json.loads(response.content)
-        except TypeError:
-            # must decode in python 3
-            res = json.loads(response.content.decode('utf8'))
+        if chunked:
+            res = json.loads("[" + response.content.decode('utf8').replace("}{", "},\n{") + "]")
+        else:
+            try:
+                res = json.loads(response.content)
+            except TypeError:
+                # must decode in python 3
+                res = json.loads(response.content.decode('utf8'))
 
         return res
 


### PR DESCRIPTION
Query with chucks works with 1 series of data. It works for simple cases. 

If there is a substring of "}{" in any of the returned points this method will explode. Seems to work well with numerical data. 
