### PR TITLE
Build matrix improvenents

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 language: python
 python:
+- 'pypy3'
+- 'pypy'
+- '3.4'
 - '3.3'
 - '3.2'
 - '2.7'
 install:
-- pip install -r requirements.txt --use-mirrors
-- pip install -r test-requirements.txt --use-mirrors
+- travis_retry pip install -r requirements.txt
+- travis_retry pip install -r test-requirements.txt
 script: nosetests
 deploy:
   provider: pypi


### PR DESCRIPTION
Added Python 3.4, PyPy and PyPy 3 to the build.
The usage of --use-mirrors is deprecated. Use travis-retry in order to avoid build failures caused by networking problems.
