### PR TITLE
Readme improvements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,7 @@ InfluxDB-Python is a client for interacting with InfluxDB_.
     :target: https://pypi.python.org/pypi/influxdb/
     :alt: License
 
+
 InfluxDB is an open-source distributed time series database, find more about InfluxDB_ at http://influxdb.com/
 
 


### PR DESCRIPTION
Solve 2 tiny problems: 
1) README.rst is more focus on his goal: reduce Tox explanation + link to Tox for futher info 
2) README.rst header is more friendly for inclusion in Sphinx documentation
