### PR TITLE
Some exceptions could be raised before sending data to server

### DIFF
--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -881,6 +881,8 @@ class InfluxDBClusterClient(object):
                 except InfluxDBClientError as e:
                     # Errors caused by user's requests, re-raise
                     raise e
+                except ValueError as e:
+                    raise e
                 except Exception as e:
                     # Errors that might caused by server failure, try another
                     bad_host = True


### PR DESCRIPTION
If this piece of code is executed:
```
from influxdb import InfluxDBClusterClient
client = InfluxDBClusterClient(
        [('10.0.0.18',8086)],"x","x","udo")

client.write_points([{"time": "1453118432", "measurement":"medida","fields": {"value": 3}}])
```
This exception is raised:
```
influxdb.exceptions.InfluxDBServerError: InfluxDB: no viable server!
```

The lib is telling us that there is some problem with the servers, but it is not actually the real problem.
The problem is using a string timestamp instead of integer.

The flow is:
https://github.com/influxdata/influxdb-python/blob/master/influxdb/client.py#L276 -> 
https://github.com/influxdata/influxdb-python/blob/master/influxdb/line_protocol.py#L131 -> https://github.com/influxdata/influxdb-python/blob/master/influxdb/line_protocol.py#L17 -> 
finally calling dateutil.parser.parse("1453120639") that raises:
```
ValueError: year is out of range
```

With this PR, that exception is catched and displayed to the user.

I think the error is assuming that all exceptions excluding InfluxDBClientError are server errors: https://github.com/influxdata/influxdb-python/blob/master/influxdb/client.py#L884