### PR TITLE
Python 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 env:
+    - TOX_ENV=py26
     - TOX_ENV=py27
     - TOX_ENV=py32
     - TOX_ENV=py33

--- a/influxdb/_dataframe_client.py
+++ b/influxdb/_dataframe_client.py
@@ -119,7 +119,7 @@ class DataFrameClient(InfluxDBClient):
                                    time_precision=None):
 
         if not isinstance(dataframe, pd.DataFrame):
-            raise TypeError('Must be DataFrame, but type was: {}.'
+            raise TypeError('Must be DataFrame, but type was: {0}.'
                             .format(type(dataframe)))
         if not (isinstance(dataframe.index, pd.tseries.period.PeriodIndex) or
                 isinstance(dataframe.index, pd.tseries.index.DatetimeIndex)):

--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -530,12 +530,12 @@ localhost:8086/databasename', timeout=5, udp_port=159)
             should be set. Otherwise the operation will fail.
         """
         query_string = (
-            "ALTER RETENTION POLICY {} ON {}"
+            "ALTER RETENTION POLICY {0} ON {1}"
         ).format(name, database or self._database)
         if duration:
-            query_string += " DURATION {}".format(duration)
+            query_string += " DURATION {0}".format(duration)
         if replication:
-            query_string += " REPLICATION {}".format(replication)
+            query_string += " REPLICATION {0}".format(replication)
         if default is True:
             query_string += " DEFAULT"
 
@@ -643,7 +643,7 @@ localhost:8086/databasename', timeout=5, udp_port=159)
             privileges or not
         :type admin: boolean
         """
-        text = "CREATE USER {} WITH PASSWORD '{}'".format(username, password)
+        text = "CREATE USER {0} WITH PASSWORD '{1}'".format(username, password)
         if admin:
             text += ' WITH ALL PRIVILEGES'
         self.query(text)
@@ -654,7 +654,7 @@ localhost:8086/databasename', timeout=5, udp_port=159)
         :param username: the username to drop
         :type username: str
         """
-        text = "DROP USER {}".format(username)
+        text = "DROP USER {0}".format(username)
         self.query(text)
 
     def set_user_password(self, username, password):
@@ -665,7 +665,7 @@ localhost:8086/databasename', timeout=5, udp_port=159)
         :param password: the new password for the user
         :type password: str
         """
-        text = "SET PASSWORD FOR {} = '{}'".format(username, password)
+        text = "SET PASSWORD FOR {0} = '{1}'".format(username, password)
         self.query(text)
 
     def delete_series(self, database=None, measurement=None, tags=None):
@@ -683,10 +683,10 @@ localhost:8086/databasename', timeout=5, udp_port=159)
         database = database or self._database
         query_str = 'DROP SERIES'
         if measurement:
-            query_str += ' FROM "{}"'.format(measurement)
+            query_str += ' FROM "{0}"'.format(measurement)
 
         if tags:
-            query_str += ' WHERE ' + ' and '.join(["{}='{}'".format(k, v)
+            query_str += ' WHERE ' + ' and '.join(["{0}='{1}'".format(k, v)
                                                    for k, v in tags.items()])
         self.query(query_str, database=database)
 
@@ -699,7 +699,7 @@ localhost:8086/databasename', timeout=5, udp_port=159)
         .. note:: Only a cluster administrator can create/ drop databases
             and manage users.
         """
-        text = "REVOKE ALL PRIVILEGES FROM {}".format(username)
+        text = "REVOKE ALL PRIVILEGES FROM {0}".format(username)
         self.query(text)
 
     def grant_privilege(self, privilege, database, username):
@@ -713,7 +713,7 @@ localhost:8086/databasename', timeout=5, udp_port=159)
         :param username: the username to grant the privilege to
         :type username: str
         """
-        text = "GRANT {} ON {} TO {}".format(privilege,
+        text = "GRANT {0} ON {1} TO {2}".format(privilege,
                                              database,
                                              username)
         self.query(text)
@@ -729,7 +729,7 @@ localhost:8086/databasename', timeout=5, udp_port=159)
         :param username: the username to revoke the privilege from
         :type username: str
         """
-        text = "REVOKE {} ON {} FROM {}".format(privilege,
+        text = "REVOKE {0} ON {1} FROM {2}".format(privilege,
                                                 database,
                                                 username)
         self.query(text)
@@ -911,7 +911,7 @@ def parse_dsn(dsn):
         modifier, scheme = scheme_info
 
     if scheme != 'influxdb':
-        raise ValueError('Unknown scheme "{}".'.format(scheme))
+        raise ValueError('Unknown scheme "{0}".'.format(scheme))
 
     if modifier:
         if modifier == 'udp':
@@ -919,7 +919,7 @@ def parse_dsn(dsn):
         elif modifier == 'https':
             init_args['ssl'] = True
         else:
-            raise ValueError('Unknown modifier "{}".'.format(modifier))
+            raise ValueError('Unknown modifier "{0}".'.format(modifier))
 
     netlocs = conn_params.netloc.split(',')
 
@@ -937,7 +937,7 @@ def parse_dsn(dsn):
 
 
 def _parse_netloc(netloc):
-    info = urlparse("http://{}".format(netloc))
+    info = urlparse("http://{0}".format(netloc))
     return {'username': info.username or None,
             'password': info.password or None,
             'host': info.hostname or 'localhost',

--- a/influxdb/helper.py
+++ b/influxdb/helper.py
@@ -51,7 +51,7 @@ class SeriesHelper(object):
                 _meta = getattr(cls, 'Meta')
             except AttributeError:
                 raise AttributeError(
-                    'Missing Meta class in {}.'.format(
+                    'Missing Meta class in {0}.'.format(
                         cls.__name__))
 
             for attr in ['series_name', 'fields', 'tags']:
@@ -59,7 +59,7 @@ class SeriesHelper(object):
                     setattr(cls, '_' + attr, getattr(_meta, attr))
                 except AttributeError:
                     raise AttributeError(
-                        'Missing {} in {} Meta class.'.format(
+                        'Missing {0} in {1} Meta class.'.format(
                             attr,
                             cls.__name__))
 
@@ -68,14 +68,14 @@ class SeriesHelper(object):
             cls._client = getattr(_meta, 'client', None)
             if cls._autocommit and not cls._client:
                 raise AttributeError(
-                    'In {}, autocommit is set to True, but no client is set.'
+                    'In {0}, autocommit is set to True, but no client is set.'
                     .format(cls.__name__))
 
             try:
                 cls._bulk_size = getattr(_meta, 'bulk_size')
                 if cls._bulk_size < 1 and cls._autocommit:
                     warn(
-                        'Definition of bulk_size in {} forced to 1, '
+                        'Definition of bulk_size in {0} forced to 1, '
                         'was less than 1.'.format(cls.__name__))
                     cls._bulk_size = 1
             except AttributeError:
@@ -83,7 +83,7 @@ class SeriesHelper(object):
             else:
                 if not cls._autocommit:
                     warn(
-                        'Definition of bulk_size in {} has no affect because'
+                        'Definition of bulk_size in {0} has no affect because'
                         ' autocommit is false.'.format(cls.__name__))
 
             cls._datapoints = defaultdict(list)

--- a/influxdb/influxdb08/client.py
+++ b/influxdb/influxdb08/client.py
@@ -145,14 +145,14 @@ class InfluxDBClient(object):
             modifier, scheme = scheme_info
 
         if scheme != 'influxdb':
-            raise ValueError('Unknown scheme "{}".'.format(scheme))
+            raise ValueError('Unknown scheme "{0}".'.format(scheme))
         if modifier:
             if modifier == 'udp':
                 init_args['use_udp'] = True
             elif modifier == 'https':
                 init_args['ssl'] = True
             else:
-                raise ValueError('Unknown modifier "{}".'.format(modifier))
+                raise ValueError('Unknown modifier "{0}".'.format(modifier))
 
         if conn_params.hostname:
             init_args['host'] = conn_params.hostname
@@ -838,7 +838,7 @@ class InfluxDBClient(object):
         url = "db/{0}/users/{1}".format(self._database, username)
 
         if not password and not permissions:
-            raise ValueError("Nothing to alter for user {}.".format(username))
+            raise ValueError("Nothing to alter for user {0}.".format(username))
 
         data = {}
 

--- a/influxdb/influxdb08/dataframe_client.py
+++ b/influxdb/influxdb08/dataframe_client.py
@@ -121,7 +121,7 @@ class DataFrameClient(InfluxDBClient):
 
     def _convert_dataframe_to_json(self, dataframe, name, time_precision='s'):
         if not isinstance(dataframe, pd.DataFrame):
-            raise TypeError('Must be DataFrame, but type was: {}.'
+            raise TypeError('Must be DataFrame, but type was: {0}.'
                             .format(type(dataframe)))
         if not (isinstance(dataframe.index, pd.tseries.period.PeriodIndex) or
                 isinstance(dataframe.index, pd.tseries.index.DatetimeIndex)):

--- a/influxdb/influxdb08/helper.py
+++ b/influxdb/influxdb08/helper.py
@@ -51,7 +51,7 @@ class SeriesHelper(object):
                 _meta = getattr(cls, 'Meta')
             except AttributeError:
                 raise AttributeError(
-                    'Missing Meta class in {}.'.format(
+                    'Missing Meta class in {0}.'.format(
                         cls.__name__))
 
             for attr in ['series_name', 'fields']:
@@ -59,7 +59,7 @@ class SeriesHelper(object):
                     setattr(cls, '_' + attr, getattr(_meta, attr))
                 except AttributeError:
                     raise AttributeError(
-                        'Missing {} in {} Meta class.'.format(
+                        'Missing {0} in {1} Meta class.'.format(
                             attr,
                             cls.__name__))
 
@@ -68,14 +68,14 @@ class SeriesHelper(object):
             cls._client = getattr(_meta, 'client', None)
             if cls._autocommit and not cls._client:
                 raise AttributeError(
-                    'In {}, autocommit is set to True, but no client is set.'
+                    'In {0}, autocommit is set to True, but no client is set.'
                     .format(cls.__name__))
 
             try:
                 cls._bulk_size = getattr(_meta, 'bulk_size')
                 if cls._bulk_size < 1 and cls._autocommit:
                     warn(
-                        'Definition of bulk_size in {} forced to 1, '
+                        'Definition of bulk_size in {0} forced to 1, '
                         'was less than 1.'.format(cls.__name__))
                     cls._bulk_size = 1
             except AttributeError:
@@ -83,7 +83,7 @@ class SeriesHelper(object):
             else:
                 if not cls._autocommit:
                     warn(
-                        'Definition of bulk_size in {} has no affect because'
+                        'Definition of bulk_size in {0} has no affect because'
                         ' autocommit is false.'.format(cls.__name__))
 
             cls._datapoints = defaultdict(list)

--- a/influxdb/line_protocol.py
+++ b/influxdb/line_protocol.py
@@ -52,7 +52,7 @@ def _escape_tag(tag):
 def _escape_value(value):
     value = _get_unicode(value)
     if isinstance(value, text_type) and value != '':
-        return "\"{}\"".format(
+        return "\"{0}\"".format(
             value.replace(
                 "\"", "\\\""
             ).replace(

--- a/influxdb/tests/__init__.py
+++ b/influxdb/tests/__init__.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
-import unittest
 import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 import os
 
 using_pypy = hasattr(sys, "pypy_version_info")

--- a/influxdb/tests/chunked_json_test.py
+++ b/influxdb/tests/chunked_json_test.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 
-import unittest
+import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 
 from influxdb import chunked_json
 

--- a/influxdb/tests/client_test.py
+++ b/influxdb/tests/client_test.py
@@ -19,13 +19,17 @@ import requests
 import requests.exceptions
 import socket
 import time
-import unittest
 import requests_mock
 import random
 from nose.tools import raises
 from mock import patch
 import warnings
 import mock
+import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 
 from influxdb import InfluxDBClient, InfluxDBClusterClient
 from influxdb.client import InfluxDBServerError

--- a/influxdb/tests/dataframe_client_test.py
+++ b/influxdb/tests/dataframe_client_test.py
@@ -4,7 +4,11 @@ unit tests for misc module
 """
 from .client_test import _mocked_session
 
-import unittest
+import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 import json
 import requests_mock
 from nose.tools import raises

--- a/influxdb/tests/helper_test.py
+++ b/influxdb/tests/helper_test.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 
-import unittest
+import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 import warnings
 
 import mock
@@ -117,7 +121,7 @@ class TestSeriesHelper(unittest.TestCase):
         self.assertTrue(all([el in expectation for el in rcvd]) and
                         all([el in rcvd for el in expectation]),
                         'Invalid JSON body of time series returned from '
-                        '_json_body_ for one series name: {}.'.format(rcvd))
+                        '_json_body_ for one series name: {0}.'.format(rcvd))
         TestSeriesHelper.MySeriesHelper._reset_()
         self.assertEqual(
             TestSeriesHelper.MySeriesHelper._json_body_(),
@@ -183,7 +187,7 @@ class TestSeriesHelper(unittest.TestCase):
         self.assertTrue(all([el in expectation for el in rcvd]) and
                         all([el in rcvd for el in expectation]),
                         'Invalid JSON body of time series returned from '
-                        '_json_body_ for several series names: {}.'
+                        '_json_body_ for several series names: {0}.'
                         .format(rcvd))
         TestSeriesHelper.MySeriesHelper._reset_()
         self.assertEqual(
@@ -245,7 +249,7 @@ class TestSeriesHelper(unittest.TestCase):
                 # the warning only.
                 pass
             self.assertEqual(len(w), 1,
-                             '{} call should have generated one warning.'
+                             '{0} call should have generated one warning.'
                              .format(WarnBulkSizeZero))
             self.assertIn('forced to 1', str(w[-1].message),
                           'Warning message did not contain "forced to 1".')
@@ -267,7 +271,7 @@ class TestSeriesHelper(unittest.TestCase):
             warnings.simplefilter("always")
             WarnBulkSizeNoEffect(time=159, server_name='us.east-1')
             self.assertEqual(len(w), 1,
-                             '{} call should have generated one warning.'
+                             '{0} call should have generated one warning.'
                              .format(WarnBulkSizeNoEffect))
             self.assertIn('has no affect', str(w[-1].message),
                           'Warning message did not contain "has not affect".')

--- a/influxdb/tests/influxdb08/client_test.py
+++ b/influxdb/tests/influxdb08/client_test.py
@@ -6,7 +6,11 @@ import json
 import requests
 import requests.exceptions
 import socket
-import unittest
+import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 import requests_mock
 import random
 from nose.tools import raises

--- a/influxdb/tests/influxdb08/dataframe_client_test.py
+++ b/influxdb/tests/influxdb08/dataframe_client_test.py
@@ -4,7 +4,11 @@ unit tests for misc module
 """
 from .client_test import _mocked_session
 
-import unittest
+import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 import json
 import requests_mock
 from nose.tools import raises

--- a/influxdb/tests/influxdb08/helper_test.py
+++ b/influxdb/tests/influxdb08/helper_test.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 
-import unittest
+import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 import warnings
 
 import mock
@@ -75,7 +79,7 @@ class TestSeriesHelper(unittest.TestCase):
         self.assertTrue(all([el in expectation for el in rcvd]) and
                         all([el in rcvd for el in expectation]),
                         'Invalid JSON body of time series returned from '
-                        '_json_body_ for one series name: {}.'.format(rcvd))
+                        '_json_body_ for one series name: {0}.'.format(rcvd))
         TestSeriesHelper.MySeriesHelper._reset_()
         self.assertEqual(
             TestSeriesHelper.MySeriesHelper._json_body_(),

--- a/influxdb/tests/influxdb08/helper_test.py
+++ b/influxdb/tests/influxdb08/helper_test.py
@@ -111,7 +111,7 @@ class TestSeriesHelper(unittest.TestCase):
         self.assertTrue(all([el in expectation for el in rcvd]) and
                         all([el in rcvd for el in expectation]),
                         'Invalid JSON body of time series returned from '
-                        '_json_body_ for several series names: {}.'
+                        '_json_body_ for several series names: {0}.'
                         .format(rcvd))
         TestSeriesHelper.MySeriesHelper._reset_()
         self.assertEqual(
@@ -171,8 +171,8 @@ class TestSeriesHelper(unittest.TestCase):
 
         self.assertGreaterEqual(
             len(rec_warnings), 1,
-            '{} call should have generated one warning.'
-            'Actual generated warnings: {}'.format(
+            '{0} call should have generated one warning.'
+            'Actual generated warnings: {1}'.format(
                 WarnBulkSizeZero, '\n'.join(map(str, rec_warnings))))
 
         expected_msg = (
@@ -201,8 +201,8 @@ class TestSeriesHelper(unittest.TestCase):
 
         self.assertGreaterEqual(
             len(rec_warnings), 1,
-            '{} call should have generated one warning.'
-            'Actual generated warnings: {}'.format(
+            '{0} call should have generated one warning.'
+            'Actual generated warnings: {1}'.format(
                 WarnBulkSizeNoEffect, '\n'.join(map(str, rec_warnings))))
 
         expected_msg = (

--- a/influxdb/tests/resultset_test.py
+++ b/influxdb/tests/resultset_test.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 
-import unittest
+import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 
 from influxdb.exceptions import InfluxDBClientError
 from influxdb.resultset import ResultSet

--- a/influxdb/tests/server_tests/client_test_with_server.py
+++ b/influxdb/tests/server_tests/client_test_with_server.py
@@ -15,7 +15,11 @@ from __future__ import print_function
 from functools import partial
 import os
 import time
-import unittest
+import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 import warnings
 
 # By default, raise exceptions on warnings

--- a/influxdb/tests/server_tests/influxdb_instance.py
+++ b/influxdb/tests/server_tests/influxdb_instance.py
@@ -9,10 +9,29 @@ import distutils
 import time
 import shutil
 import subprocess
-import unittest
 import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 
 from influxdb.tests.misc import is_port_open, get_free_ports
+
+# hack in check_output if it's not defined, like for python 2.6
+if "check_output" not in dir( subprocess ): 
+    def f(*popenargs, **kwargs):
+        if 'stdout' in kwargs:
+            raise ValueError('stdout argument not allowed, it will be overridden.')
+        process = subprocess.Popen(stdout=subprocess.PIPE, *popenargs, **kwargs)
+        output, unused_err = process.communicate()
+        retcode = process.poll()
+        if retcode:
+            cmd = kwargs.get("args")
+            if cmd is None:
+                cmd = popenargs[0]
+            raise subprocess.CalledProcessError(retcode, cmd)
+        return output
+    subprocess.check_output = f
 
 
 class InfluxDbInstance(object):

--- a/influxdb/tests/test_line_protocol.py
+++ b/influxdb/tests/test_line_protocol.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
 
-import unittest
+import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
 from influxdb import line_protocol
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,13 @@
 [tox]
-envlist = py34, py27, pypy, flake8
+envlist = py34, py27, py26, pypy, flake8
 
 [testenv]
 passenv = INFLUXDB_PYTHON_INFLUXD_PATH
 setenv = INFLUXDB_PYTHON_SKIP_SERVER_TESTS=False
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
-       py27,py32,py33,py34: pandas
+       py27,py32,py33,py34,py26: pandas
+       py26: unittest2
 # Only install pandas with non-pypy interpreters
 commands = nosetests -v --with-doctest {posargs}
 


### PR DESCRIPTION
This PR adds Python 2.6 support. Most of the work was in fixing the tests to use unittest2 instead of unittest for python < 2.7. The fixes to the code itself involved adding positional arguments to all of the .format() calls.

All but 1 tests passed (the CREATE DATABASE IF NOT EXIST test fails because that feature wasn't added until influxdb 0.9.4 from what I can tell, and this was testing against 0.9.3). I did not test this on anything other than py26

Should resolve #288 