### PR TITLE
create_user() - added quotes to the username

### DIFF
--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -650,7 +650,8 @@ localhost:8086/databasename', timeout=5, udp_port=159)
             privileges or not
         :type admin: boolean
         """
-        text = "CREATE USER \"{0}\" WITH PASSWORD '{1}'".format(username, password)
+        text = "CREATE USER \"{0}\" WITH PASSWORD '{1}'".format(username,
+                                                                password)
         if admin:
             text += ' WITH ALL PRIVILEGES'
         self.query(text)

--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -650,7 +650,7 @@ localhost:8086/databasename', timeout=5, udp_port=159)
             privileges or not
         :type admin: boolean
         """
-        text = "CREATE USER {0} WITH PASSWORD '{1}'".format(username, password)
+        text = "CREATE USER \"{0}\" WITH PASSWORD '{1}'".format(username, password)
         if admin:
             text += ' WITH ALL PRIVILEGES'
         self.query(text)


### PR DESCRIPTION
Created because of this issue:
This code does not work with "error parsing query":
client.create_user('aaa-bbb', 'pass', admin=False)
