### PR TITLE
Fix unicode data handling in tag's content

### DIFF
--- a/influxdb/line_protocol.py
+++ b/influxdb/line_protocol.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from numbers import Integral
 
 from dateutil.parser import parse
-from six import binary_type, text_type, integer_types
+from six import binary_type, text_type, integer_types, PY2
 
 
 def _convert_timestamp(timestamp, precision=None):
@@ -74,7 +74,10 @@ def _get_unicode(data, force=False):
     elif data is None:
         return ''
     elif force:
-        return str(data)
+        if PY2:
+            return unicode(data)
+        else:
+            return str(data)
     else:
         return data
 

--- a/influxdb/tests/test_line_protocol.py
+++ b/influxdb/tests/test_line_protocol.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 
 import sys
 if sys.version_info < (2, 7):
@@ -54,4 +55,24 @@ class TestLineProtocol(unittest.TestCase):
         self.assertEqual(
             line_protocol.make_lines(data),
             'm1 multi_line="line1\\nline1\\nline3"\n'
+        )
+
+    def test_make_lines_unicode(self):
+        data = {
+            "tags": {
+                "unicode_tag": "\'Привет!\'"  # Hello! in Russian
+            },
+            "points": [
+                {
+                    "measurement": "test",
+                    "fields": {
+                        "unicode_val": "Привет!",  # Hello! in Russian
+                    }
+                }
+            ]
+        }
+
+        self.assertEqual(
+            line_protocol.make_lines(data),
+            'test,unicode_tag=\'Привет!\' unicode_val="Привет!"\n'
         )


### PR DESCRIPTION
I'm discovered that client crashes in make_lines function if unicode data in tag content (under py27).
This patch fix it for me.