### PR TITLE
Make InfluxDBClient to force an integer as the HTTP(s) port.

### DIFF
--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -76,7 +76,7 @@ class InfluxDBClient(object):
                  ):
         """Construct a new InfluxDBClient object."""
         self.__host = host
-        self.__port = port
+        self.__port = int(port)
         self._username = username
         self._password = password
         self._database = database

--- a/influxdb/tests/client_test.py
+++ b/influxdb/tests/client_test.py
@@ -794,6 +794,10 @@ class TestInfluxDBClient(unittest.TestCase):
         with _mocked_session(cli, 'get', 400):
             self.cli.revoke_privilege('', 'testdb', 'test')
 
+    def test_invalid_port_fails(self):
+        with self.assertRaises(ValueError):
+            InfluxDBClient('host', '80/redir', 'username', 'password')
+
 
 class FakeClient(InfluxDBClient):
 

--- a/influxdb/tests/server_tests/client_test_with_server.py
+++ b/influxdb/tests/server_tests/client_test_with_server.py
@@ -295,6 +295,10 @@ class SimpleTests(SingleTestCaseWithServerMixin,
         self.assertIn('{"error":"error parsing query: ',
                       ctx.exception.content)
 
+    def test_invalid_port_fails(self):
+        with self.assertRaises(ValueError):
+            InfluxDBClient('host', '80/redir', 'username', 'password')
+
 
 @skipServerTests
 class CommonTests(ManyTestCasesWithServerMixin,

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,6 @@ commands = flake8 influxdb
 [testenv:coverage]
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
-       -r{toxinidir}/README.rst
        pandas
        coverage
 commands = nosetests -v --with-coverage --cover-html --cover-package=influxdb

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ commands = flake8 influxdb
 [testenv:coverage]
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
+       -r{toxinidir}/README.rst
        pandas
        coverage
 commands = nosetests -v --with-coverage --cover-html --cover-package=influxdb


### PR DESCRIPTION
- Includes unit tests
- Does not make the change to influxdb08
- Also a small change that was needed to tox.ini that was needed for tox to pass, since setup.py reads README.rst