### PR TITLE
Allow setting the time of a point manually.

### DIFF
--- a/influxdb/tests/helper_test.py
+++ b/influxdb/tests/helper_test.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import datetime
+import pytz
 import sys
 if sys.version_info < (2, 7):
     import unittest2 as unittest
@@ -38,6 +40,18 @@ class TestSeriesHelper(unittest.TestCase):
 
         TestSeriesHelper.MySeriesHelper = MySeriesHelper
 
+        class MySeriesTimeHelper(SeriesHelper):
+
+            class Meta:
+                client = TestSeriesHelper.client
+                series_name = 'events.stats.{server_name}'
+                fields = ['time', 'some_stat']
+                tags = ['server_name', 'other_tag']
+                bulk_size = 5
+                autocommit = True
+
+        TestSeriesHelper.MySeriesTimeHelper = MySeriesTimeHelper
+
     def test_auto_commit(self):
         """
         Tests that write_points is called after the right number of events
@@ -66,14 +80,20 @@ class TestSeriesHelper(unittest.TestCase):
         """
         Tests JSON conversion when there is only one series name.
         """
-        TestSeriesHelper.MySeriesHelper(
-            server_name='us.east-1', other_tag='ello', some_stat=159)
-        TestSeriesHelper.MySeriesHelper(
-            server_name='us.east-1', other_tag='ello', some_stat=158)
-        TestSeriesHelper.MySeriesHelper(
-            server_name='us.east-1', other_tag='ello', some_stat=157)
-        TestSeriesHelper.MySeriesHelper(
-            server_name='us.east-1', other_tag='ello', some_stat=156)
+        dt = datetime.datetime(2016, 1, 2, 3, 4, 5, 678912)
+        ts1 = dt
+        ts2 = "2016-10-11T01:02:03.123456789-04:00"
+        ts3 = 1234567890123456789
+        ts4 = pytz.timezone("Europe/Berlin").localize(dt)
+
+        TestSeriesHelper.MySeriesTimeHelper(
+            time=ts1, server_name='us.east-1', other_tag='ello', some_stat=159)
+        TestSeriesHelper.MySeriesTimeHelper(
+            time=ts2, server_name='us.east-1', other_tag='ello', some_stat=158)
+        TestSeriesHelper.MySeriesTimeHelper(
+            time=ts3, server_name='us.east-1', other_tag='ello', some_stat=157)
+        TestSeriesHelper.MySeriesTimeHelper(
+            time=ts4, server_name='us.east-1', other_tag='ello', some_stat=156)
         expectation = [
             {
                 "measurement": "events.stats.us.east-1",
@@ -84,6 +104,7 @@ class TestSeriesHelper(unittest.TestCase):
                 "fields": {
                     "some_stat": 159
                 },
+                "time": "2016-01-02T03:04:05.678912+00:00",
             },
             {
                 "measurement": "events.stats.us.east-1",
@@ -94,6 +115,7 @@ class TestSeriesHelper(unittest.TestCase):
                 "fields": {
                     "some_stat": 158
                 },
+                "time": "2016-10-11T01:02:03.123456789-04:00",
             },
             {
                 "measurement": "events.stats.us.east-1",
@@ -104,6 +126,7 @@ class TestSeriesHelper(unittest.TestCase):
                 "fields": {
                     "some_stat": 157
                 },
+                "time": 1234567890123456789,
             },
             {
                 "measurement": "events.stats.us.east-1",
@@ -114,23 +137,24 @@ class TestSeriesHelper(unittest.TestCase):
                 "fields": {
                     "some_stat": 156
                 },
+                "time": "2016-01-02T03:04:05.678912+01:00",
             }
         ]
 
-        rcvd = TestSeriesHelper.MySeriesHelper._json_body_()
+        rcvd = TestSeriesHelper.MySeriesTimeHelper._json_body_()
         self.assertTrue(all([el in expectation for el in rcvd]) and
                         all([el in rcvd for el in expectation]),
                         'Invalid JSON body of time series returned from '
                         '_json_body_ for one series name: {0}.'.format(rcvd))
-        TestSeriesHelper.MySeriesHelper._reset_()
+        TestSeriesHelper.MySeriesTimeHelper._reset_()
         self.assertEqual(
-            TestSeriesHelper.MySeriesHelper._json_body_(),
+            TestSeriesHelper.MySeriesTimeHelper._json_body_(),
             [],
             'Resetting helper did not empty datapoints.')
 
     def testSeveralSeriesNames(self):
         '''
-        Tests JSON conversion when there is only one series name.
+        Tests JSON conversion when there are multiple series names.
         '''
         TestSeriesHelper.MySeriesHelper(
             server_name='us.east-1', some_stat=159, other_tag='ello')
@@ -184,6 +208,10 @@ class TestSeriesHelper(unittest.TestCase):
         ]
 
         rcvd = TestSeriesHelper.MySeriesHelper._json_body_()
+        for r in rcvd:
+            self.assertTrue(r.get('time'),
+                            "No time field in received JSON body.")
+            del(r["time"])
         self.assertTrue(all([el in expectation for el in rcvd]) and
                         all([el in rcvd for el in expectation]),
                         'Invalid JSON body of time series returned from '

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,3 +2,4 @@ nose
 nose-cov
 mock
 requests-mock
+pytz


### PR DESCRIPTION
Point can be specified as either a number of nanoseconds, a python
datetime object (with or without timezone) or a string in ISO datetime
format.

If a time is not specified, the Helper sets the time at the time of
assembling the point fields so that multiple unique points with the same
tags can be committed simultaneously without them failing to add due to
all being assigned the same automatic time by the InfluxDB server.

This fix is based upon the discussion in #130 but also includes the
outstanding items for it to be merged. I'm happy to receive suggestions
for further ways to add test coverage to this change.

This also fixes #264 and fixes #259.