### PR TITLE
Add time parameter to SeriesHelper

### DIFF
--- a/influxdb/helper.py
+++ b/influxdb/helper.py
@@ -16,6 +16,9 @@ class SeriesHelper(object):
     All data points are immutable, insuring they do not get overwritten.
     Each subclass can write to its own database.
     The time series names can also be based on one or more defined fields.
+    The field "time" can be specified when creating a point, and may be any of
+    the time types supported by the client (i.e. str, datetime, int).
+    If the time is not specified, the current system time (utc) will be used.
 
     Annotated example::
 

--- a/influxdb/helper.py
+++ b/influxdb/helper.py
@@ -103,7 +103,7 @@ class SeriesHelper(object):
         :warning: Data points are *immutable* (`namedtuples`).
         """
         cls = self.__class__
-        timestamp = kw.pop('time', time.time())
+        timestamp = kw.pop('time', self._current_timestamp())
 
         if sorted(cls._fields + cls._tags) != sorted(kw.keys()):
             raise NameError(
@@ -165,3 +165,6 @@ class SeriesHelper(object):
         Reset data storage.
         """
         cls._datapoints = defaultdict(list)
+
+    def _current_timestamp(self):
+        return time.time()

--- a/influxdb/helper.py
+++ b/influxdb/helper.py
@@ -3,10 +3,10 @@
 Helper class for InfluxDB
 """
 from collections import namedtuple, defaultdict
+from datetime import datetime
 from warnings import warn
 
 import six
-import time
 
 
 class SeriesHelper(object):
@@ -167,4 +167,4 @@ class SeriesHelper(object):
         cls._datapoints = defaultdict(list)
 
     def _current_timestamp(self):
-        return time.time()
+        return datetime.utcnow()

--- a/influxdb/helper.py
+++ b/influxdb/helper.py
@@ -3,7 +3,6 @@
 Helper class for InfluxDB
 """
 from collections import namedtuple, defaultdict
-from datetime import datetime
 from warnings import warn
 
 import six
@@ -16,16 +15,6 @@ class SeriesHelper(object):
     All data points are immutable, insuring they do not get overwritten.
     Each subclass can write to its own database.
     The time series names can also be based on one or more defined fields.
-
-    A field "time" can be used to write data points at a specific time,
-    rather than the default current time. The time field can take any of
-    the following forms:
-     * An integer unix timestamp in nanoseconds, assumed to be in UTC.
-     * A string in the ISO time format, including a timezone.
-     * A naive python datetime, which will be treated as UTC.
-     * A localized python datetime, which will use the chosen timezone.
-    If no time field is provided, the current UTC system time in microseconds
-    at the time of assembling the point data will be used.
 
     Annotated example::
 
@@ -153,23 +142,8 @@ class SeriesHelper(object):
                     "tags": {},
                 }
 
-                ts = getattr(point, 'time', None)
-                if not ts:
-                    # No time provided. Use current UTC time.
-                    ts = datetime.utcnow().isoformat() + "+00:00"
-                elif isinstance(ts, datetime):
-                    if ts.tzinfo is None or ts.tzinfo.utcoffset(ts) is None:
-                        # Assuming naive datetime provided. Format with UTC tz.
-                        ts = ts.isoformat() + "+00:00"
-                    else:
-                        # Assuming localized datetime provided.
-                        ts = ts.isoformat()
-                # Neither of the above match. Assuming correct string or int.
-                json_point['time'] = ts
-
                 for field in cls._fields:
-                    if field != 'time':
-                        json_point['fields'][field] = getattr(point, field)
+                    json_point['fields'][field] = getattr(point, field)
 
                 for tag in cls._tags:
                     json_point['tags'][tag] = getattr(point, tag)

--- a/influxdb/tests/helper_test.py
+++ b/influxdb/tests/helper_test.py
@@ -8,6 +8,8 @@ else:
 import warnings
 
 import mock
+from datetime import datetime
+from unittest.mock import patch
 from influxdb import SeriesHelper, InfluxDBClient
 from requests.exceptions import ConnectionError
 
@@ -62,10 +64,12 @@ class TestSeriesHelper(unittest.TestCase):
         AutoCommitTest(server_name='us.east-1', some_stat=3443, other_tag='gg')
         self.assertTrue(fake_write_points.called)
 
-    def testSingleSeriesName(self):
+    @patch('influxdb.helper.SeriesHelper._current_timestamp')
+    def testSingleSeriesName(self, current_timestamp):
         """
         Tests JSON conversion when there is only one series name.
         """
+        current_timestamp.return_value = current_date = datetime.today()
         TestSeriesHelper.MySeriesHelper(
             server_name='us.east-1', other_tag='ello', some_stat=159)
         TestSeriesHelper.MySeriesHelper(
@@ -84,6 +88,7 @@ class TestSeriesHelper(unittest.TestCase):
                 "fields": {
                     "some_stat": 159
                 },
+                "time": current_date,
             },
             {
                 "measurement": "events.stats.us.east-1",
@@ -94,6 +99,7 @@ class TestSeriesHelper(unittest.TestCase):
                 "fields": {
                     "some_stat": 158
                 },
+                "time": current_date,
             },
             {
                 "measurement": "events.stats.us.east-1",
@@ -104,6 +110,7 @@ class TestSeriesHelper(unittest.TestCase):
                 "fields": {
                     "some_stat": 157
                 },
+                "time": current_date,
             },
             {
                 "measurement": "events.stats.us.east-1",
@@ -114,6 +121,7 @@ class TestSeriesHelper(unittest.TestCase):
                 "fields": {
                     "some_stat": 156
                 },
+                "time": current_date,
             }
         ]
 
@@ -128,10 +136,12 @@ class TestSeriesHelper(unittest.TestCase):
             [],
             'Resetting helper did not empty datapoints.')
 
-    def testSeveralSeriesNames(self):
-        '''
-        Tests JSON conversion when there is only one series name.
-        '''
+    @patch('influxdb.helper.SeriesHelper._current_timestamp')
+    def testSeveralSeriesNames(self, current_timestamp):
+        """
+        Tests JSON conversion when there are multiple series names.
+        """
+        current_timestamp.return_value = current_date = datetime.today()
         TestSeriesHelper.MySeriesHelper(
             server_name='us.east-1', some_stat=159, other_tag='ello')
         TestSeriesHelper.MySeriesHelper(
@@ -149,7 +159,8 @@ class TestSeriesHelper(unittest.TestCase):
                 'tags': {
                     'other_tag': 'ello',
                     'server_name': 'lu.lux'
-                }
+                },
+                "time": current_date,
             },
             {
                 'fields': {
@@ -159,7 +170,8 @@ class TestSeriesHelper(unittest.TestCase):
                 'tags': {
                     'other_tag': 'ello',
                     'server_name': 'uk.london'
-                }
+                },
+                "time": current_date,
             },
             {
                 'fields': {
@@ -169,7 +181,8 @@ class TestSeriesHelper(unittest.TestCase):
                 'tags': {
                     'other_tag': 'ello',
                     'server_name': 'fr.paris-10'
-                }
+                },
+                "time": current_date,
             },
             {
                 'fields': {
@@ -179,7 +192,8 @@ class TestSeriesHelper(unittest.TestCase):
                 'tags': {
                     'other_tag': 'ello',
                     'server_name': 'us.east-1'
-                }
+                },
+                "time": current_date,
             }
         ]
 

--- a/influxdb/tests/helper_test.py
+++ b/influxdb/tests/helper_test.py
@@ -40,6 +40,14 @@ class TestSeriesHelper(unittest.TestCase):
 
         TestSeriesHelper.MySeriesHelper = MySeriesHelper
 
+    def tearDown(self):
+        super(TestSeriesHelper, self).tearDown()
+        TestSeriesHelper.MySeriesHelper._reset_()
+        self.assertEqual(
+            TestSeriesHelper.MySeriesHelper._json_body_(),
+            [],
+            'Resetting helper did not empty datapoints.')
+
     def test_auto_commit(self):
         """
         Tests that write_points is called after the right number of events
@@ -130,11 +138,6 @@ class TestSeriesHelper(unittest.TestCase):
                         all([el in rcvd for el in expectation]),
                         'Invalid JSON body of time series returned from '
                         '_json_body_ for one series name: {0}.'.format(rcvd))
-        TestSeriesHelper.MySeriesHelper._reset_()
-        self.assertEqual(
-            TestSeriesHelper.MySeriesHelper._json_body_(),
-            [],
-            'Resetting helper did not empty datapoints.')
 
     @patch('influxdb.helper.SeriesHelper._current_timestamp')
     def testSeveralSeriesNames(self, current_timestamp):
@@ -203,11 +206,6 @@ class TestSeriesHelper(unittest.TestCase):
                         'Invalid JSON body of time series returned from '
                         '_json_body_ for several series names: {0}.'
                         .format(rcvd))
-        TestSeriesHelper.MySeriesHelper._reset_()
-        self.assertEqual(
-            TestSeriesHelper.MySeriesHelper._json_body_(),
-            [],
-            'Resetting helper did not empty datapoints.')
 
     @patch('influxdb.helper.SeriesHelper._current_timestamp')
     def testSeriesWithoutTimeField(self, current_timestamp):
@@ -229,11 +227,6 @@ class TestSeriesHelper(unittest.TestCase):
         self.assertTrue('time' in point1 and 'time' in point2)
         self.assertEqual(point1['time'], current_date)
         self.assertEqual(point2['time'], yesterday)
-        TestSeriesHelper.MySeriesHelper._reset_()
-        self.assertEqual(
-            TestSeriesHelper.MySeriesHelper._json_body_(),
-            [],
-            'Resetting helper did not empty datapoints.')
 
     @patch('influxdb.helper.SeriesHelper._current_timestamp')
     def testSeriesWithTimeField(self, current_timestamp):

--- a/influxdb/tests/helper_test.py
+++ b/influxdb/tests/helper_test.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import datetime
-import pytz
 import sys
 if sys.version_info < (2, 7):
     import unittest2 as unittest
@@ -40,18 +38,6 @@ class TestSeriesHelper(unittest.TestCase):
 
         TestSeriesHelper.MySeriesHelper = MySeriesHelper
 
-        class MySeriesTimeHelper(SeriesHelper):
-
-            class Meta:
-                client = TestSeriesHelper.client
-                series_name = 'events.stats.{server_name}'
-                fields = ['time', 'some_stat']
-                tags = ['server_name', 'other_tag']
-                bulk_size = 5
-                autocommit = True
-
-        TestSeriesHelper.MySeriesTimeHelper = MySeriesTimeHelper
-
     def test_auto_commit(self):
         """
         Tests that write_points is called after the right number of events
@@ -80,20 +66,14 @@ class TestSeriesHelper(unittest.TestCase):
         """
         Tests JSON conversion when there is only one series name.
         """
-        dt = datetime.datetime(2016, 1, 2, 3, 4, 5, 678912)
-        ts1 = dt
-        ts2 = "2016-10-11T01:02:03.123456789-04:00"
-        ts3 = 1234567890123456789
-        ts4 = pytz.timezone("Europe/Berlin").localize(dt)
-
-        TestSeriesHelper.MySeriesTimeHelper(
-            time=ts1, server_name='us.east-1', other_tag='ello', some_stat=159)
-        TestSeriesHelper.MySeriesTimeHelper(
-            time=ts2, server_name='us.east-1', other_tag='ello', some_stat=158)
-        TestSeriesHelper.MySeriesTimeHelper(
-            time=ts3, server_name='us.east-1', other_tag='ello', some_stat=157)
-        TestSeriesHelper.MySeriesTimeHelper(
-            time=ts4, server_name='us.east-1', other_tag='ello', some_stat=156)
+        TestSeriesHelper.MySeriesHelper(
+            server_name='us.east-1', other_tag='ello', some_stat=159)
+        TestSeriesHelper.MySeriesHelper(
+            server_name='us.east-1', other_tag='ello', some_stat=158)
+        TestSeriesHelper.MySeriesHelper(
+            server_name='us.east-1', other_tag='ello', some_stat=157)
+        TestSeriesHelper.MySeriesHelper(
+            server_name='us.east-1', other_tag='ello', some_stat=156)
         expectation = [
             {
                 "measurement": "events.stats.us.east-1",
@@ -104,7 +84,6 @@ class TestSeriesHelper(unittest.TestCase):
                 "fields": {
                     "some_stat": 159
                 },
-                "time": "2016-01-02T03:04:05.678912+00:00",
             },
             {
                 "measurement": "events.stats.us.east-1",
@@ -115,7 +94,6 @@ class TestSeriesHelper(unittest.TestCase):
                 "fields": {
                     "some_stat": 158
                 },
-                "time": "2016-10-11T01:02:03.123456789-04:00",
             },
             {
                 "measurement": "events.stats.us.east-1",
@@ -126,7 +104,6 @@ class TestSeriesHelper(unittest.TestCase):
                 "fields": {
                     "some_stat": 157
                 },
-                "time": 1234567890123456789,
             },
             {
                 "measurement": "events.stats.us.east-1",
@@ -137,24 +114,23 @@ class TestSeriesHelper(unittest.TestCase):
                 "fields": {
                     "some_stat": 156
                 },
-                "time": "2016-01-02T03:04:05.678912+01:00",
             }
         ]
 
-        rcvd = TestSeriesHelper.MySeriesTimeHelper._json_body_()
+        rcvd = TestSeriesHelper.MySeriesHelper._json_body_()
         self.assertTrue(all([el in expectation for el in rcvd]) and
                         all([el in rcvd for el in expectation]),
                         'Invalid JSON body of time series returned from '
                         '_json_body_ for one series name: {0}.'.format(rcvd))
-        TestSeriesHelper.MySeriesTimeHelper._reset_()
+        TestSeriesHelper.MySeriesHelper._reset_()
         self.assertEqual(
-            TestSeriesHelper.MySeriesTimeHelper._json_body_(),
+            TestSeriesHelper.MySeriesHelper._json_body_(),
             [],
             'Resetting helper did not empty datapoints.')
 
     def testSeveralSeriesNames(self):
         '''
-        Tests JSON conversion when there are multiple series names.
+        Tests JSON conversion when there is only one series name.
         '''
         TestSeriesHelper.MySeriesHelper(
             server_name='us.east-1', some_stat=159, other_tag='ello')
@@ -208,10 +184,6 @@ class TestSeriesHelper(unittest.TestCase):
         ]
 
         rcvd = TestSeriesHelper.MySeriesHelper._json_body_()
-        for r in rcvd:
-            self.assertTrue(r.get('time'),
-                            "No time field in received JSON body.")
-            del(r["time"])
         self.assertTrue(all([el in expectation for el in rcvd]) and
                         all([el in rcvd for el in expectation]),
                         'Invalid JSON body of time series returned from '

--- a/influxdb/tests/helper_test.py
+++ b/influxdb/tests/helper_test.py
@@ -9,7 +9,6 @@ import warnings
 
 import mock
 from datetime import datetime, timedelta
-from unittest.mock import patch
 from influxdb import SeriesHelper, InfluxDBClient
 from requests.exceptions import ConnectionError
 
@@ -72,7 +71,7 @@ class TestSeriesHelper(unittest.TestCase):
         AutoCommitTest(server_name='us.east-1', some_stat=3443, other_tag='gg')
         self.assertTrue(fake_write_points.called)
 
-    @patch('influxdb.helper.SeriesHelper._current_timestamp')
+    @mock.patch('influxdb.helper.SeriesHelper._current_timestamp')
     def testSingleSeriesName(self, current_timestamp):
         """
         Tests JSON conversion when there is only one series name.
@@ -139,7 +138,7 @@ class TestSeriesHelper(unittest.TestCase):
                         'Invalid JSON body of time series returned from '
                         '_json_body_ for one series name: {0}.'.format(rcvd))
 
-    @patch('influxdb.helper.SeriesHelper._current_timestamp')
+    @mock.patch('influxdb.helper.SeriesHelper._current_timestamp')
     def testSeveralSeriesNames(self, current_timestamp):
         """
         Tests JSON conversion when there are multiple series names.
@@ -207,7 +206,7 @@ class TestSeriesHelper(unittest.TestCase):
                         '_json_body_ for several series names: {0}.'
                         .format(rcvd))
 
-    @patch('influxdb.helper.SeriesHelper._current_timestamp')
+    @mock.patch('influxdb.helper.SeriesHelper._current_timestamp')
     def testSeriesWithoutTimeField(self, current_timestamp):
         """
         Tests that time is optional on a series without a time field.
@@ -228,7 +227,7 @@ class TestSeriesHelper(unittest.TestCase):
         self.assertEqual(point1['time'], current_date)
         self.assertEqual(point2['time'], yesterday)
 
-    @patch('influxdb.helper.SeriesHelper._current_timestamp')
+    @mock.patch('influxdb.helper.SeriesHelper._current_timestamp')
     def testSeriesWithTimeField(self, current_timestamp):
         """
         Test that time is optional on a series with a time field.

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,4 +2,3 @@ nose
 nose-cov
 mock
 requests-mock
-pytz


### PR DESCRIPTION
This PR replaces #130 and takes into account the feedback from that discussion.

This will allow the time to be specified when creating a point with `SeriesHelper`. This can be done regardless of whether *time* was declared as a field in the `SeriesHelper.Meta` class. 

If time is not specified the implementation defaults to using `datetime.utcnow()`. This occurs at point-creation, not within the call to `_json_body_()`. This is important because to solve #264/#259 successive points within the same series should still be retained. If the time is recorded in `_json_body_()`, the points end up all having approximately the same time and you end up with a race condition and inaccurate timestamps.

As I've added to the docstring for `SeriesHelper`, the time can be any of the time types supported by the client (see [line_protocol.py#L13](https://github.com/influxdata/influxdb-python/blob/master/influxdb/line_protocol.py#L13)).  A nice thing about using a `datetime` object as the default, is that this leverages the existing precision handling in `_convert_timestamp()`.

One area on which I'd like feedback, is whether it's undesirable that if 'time' is specified as a field, but not specified at point-creation, that it won't raise a `NameError` as per the usual logic for missing fields/tags in [helper.py#L104](https://github.com/influxdata/influxdb-python/blob/master/influxdb/helper.py#L104).