### PR TITLE
Add support for shard duration in retention policies

### DIFF
--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -482,7 +482,8 @@ localhost:8086/databasename', timeout=5, udp_port=159)
         self.query("DROP DATABASE \"%s\"" % dbname)
 
     def create_retention_policy(self, name, duration, replication,
-                                database=None, default=False):
+                                database=None, default=False,
+                                shard_duration=None):
         """Create a retention policy for a database.
 
         :param name: the name of the new retention policy
@@ -501,11 +502,17 @@ localhost:8086/databasename', timeout=5, udp_port=159)
         :type database: str
         :param default: whether or not to set the policy as default
         :type default: bool
+        :param shard_duration: the shard duration of the retention policy.
+            Durations are similar to those allowed in the duration param.
+        :type shard_duration: str
         """
         query_string = \
             "CREATE RETENTION POLICY \"%s\" ON \"%s\" " \
             "DURATION %s REPLICATION %s" % \
             (name, database or self._database, duration, replication)
+
+        if shard_duration:
+            query_string += " SHARD DURATION %s" % shard_duration
 
         if default is True:
             query_string += " DEFAULT"
@@ -513,7 +520,8 @@ localhost:8086/databasename', timeout=5, udp_port=159)
         self.query(query_string)
 
     def alter_retention_policy(self, name, database=None,
-                               duration=None, replication=None, default=None):
+                               duration=None, replication=None, default=None,
+                               shard_duration=None):
         """Mofidy an existing retention policy for a database.
 
         :param name: the name of the retention policy to modify
@@ -533,9 +541,13 @@ localhost:8086/databasename', timeout=5, udp_port=159)
         :type replication: str
         :param default: whether or not to set the modified policy as default
         :type default: bool
+        :param shard_duration: the shard duration of the retention policy.
+            Durations are similar to those allowed in the duration param.
+        :type shard_duration: str
 
-        .. note:: at least one of duration, replication, or default flag
-            should be set. Otherwise the operation will fail.
+        .. note:: at least one of duration, replication, default or
+            shard_duration flag should be set. Otherwise the operation
+            will fail.
         """
         query_string = (
             "ALTER RETENTION POLICY \"{0}\" ON \"{1}\""
@@ -544,6 +556,8 @@ localhost:8086/databasename', timeout=5, udp_port=159)
             query_string += " DURATION {0}".format(duration)
         if replication:
             query_string += " REPLICATION {0}".format(replication)
+        if shard_duration:
+            query_string += " SHARD DURATION {0}".format(shard_duration)
         if default is True:
             query_string += " DEFAULT"
 

--- a/influxdb/tests/client_test.py
+++ b/influxdb/tests/client_test.py
@@ -555,6 +555,47 @@ class TestInfluxDBClient(unittest.TestCase):
                 '"db" duration 1d replication 4'
             )
 
+    def test_create_retention_policy_shard_duration(self):
+        example_response = '{"results":[{}]}'
+
+        with requests_mock.Mocker() as m:
+            m.register_uri(
+                requests_mock.GET,
+                "http://localhost:8086/query",
+                text=example_response
+            )
+            self.cli.create_retention_policy(
+                'somename2', '1d', 4, database='db',
+                shard_duration='1h'
+            )
+
+            self.assertEqual(
+                m.last_request.qs['q'][0],
+                'create retention policy "somename2" on '
+                '"db" duration 1d replication 4 shard duration 1h'
+            )
+
+    def test_create_retention_policy_shard_duration_default(self):
+        example_response = '{"results":[{}]}'
+
+        with requests_mock.Mocker() as m:
+            m.register_uri(
+                requests_mock.GET,
+                "http://localhost:8086/query",
+                text=example_response
+            )
+            self.cli.create_retention_policy(
+                'somename3', '1d', 4, database='db',
+                shard_duration='1h', default=True
+            )
+
+            self.assertEqual(
+                m.last_request.qs['q'][0],
+                'create retention policy "somename3" on '
+                '"db" duration 1d replication 4 shard duration 1h '
+                'default'
+            )
+
     def test_alter_retention_policy(self):
         example_response = '{"results":[{}]}'
 


### PR DESCRIPTION
- SHARD DURATION was added in 45b3e61, this adds support to the python
  client so it can be modified/added
