### PR TITLE
Updated client retention policy functionality to escape/backtick database and policy name

### DIFF
--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -502,7 +502,7 @@ localhost:8086/databasename', timeout=5, udp_port=159)
         :type default: bool
         """
         query_string = \
-            "CREATE RETENTION POLICY %s ON %s " \
+            "CREATE RETENTION POLICY \"%s\" ON \"%s\" " \
             "DURATION %s REPLICATION %s" % \
             (name, database or self._database, duration, replication)
 
@@ -537,7 +537,7 @@ localhost:8086/databasename', timeout=5, udp_port=159)
             should be set. Otherwise the operation will fail.
         """
         query_string = (
-            "ALTER RETENTION POLICY {0} ON {1}"
+            "ALTER RETENTION POLICY \"{0}\" ON \"{1}\""
         ).format(name, database or self._database)
         if duration:
             query_string += " DURATION {0}".format(duration)
@@ -558,7 +558,7 @@ localhost:8086/databasename', timeout=5, udp_port=159)
         :type database: str
         """
         query_string = (
-            "DROP RETENTION POLICY {0} ON {1}"
+            "DROP RETENTION POLICY \"{0}\" ON \"{1}\""
         ).format(name, database or self._database)
         self.query(query_string)
 
@@ -583,7 +583,7 @@ localhost:8086/databasename', timeout=5, udp_port=159)
               u'replicaN': 1}]
             """
         rsp = self.query(
-            "SHOW RETENTION POLICIES ON %s" % (database or self._database)
+            "SHOW RETENTION POLICIES ON \"%s\"" % (database or self._database)
         )
         return list(rsp.get_points())
 

--- a/influxdb/tests/client_test.py
+++ b/influxdb/tests/client_test.py
@@ -571,8 +571,8 @@ class TestInfluxDBClient(unittest.TestCase):
 
             self.assertEqual(
                 m.last_request.qs['q'][0],
-                'create retention policy somename on '
-                'db duration 1d replication 4 default'
+                'create retention policy "somename" on '
+                '"db" duration 1d replication 4 default'
             )
 
     def test_create_retention_policy(self):
@@ -590,8 +590,8 @@ class TestInfluxDBClient(unittest.TestCase):
 
             self.assertEqual(
                 m.last_request.qs['q'][0],
-                'create retention policy somename on '
-                'db duration 1d replication 4'
+                'create retention policy "somename" on '
+                '"db" duration 1d replication 4'
             )
 
     def test_alter_retention_policy(self):
@@ -608,14 +608,14 @@ class TestInfluxDBClient(unittest.TestCase):
                                             duration='4d')
             self.assertEqual(
                 m.last_request.qs['q'][0],
-                'alter retention policy somename on db duration 4d'
+                'alter retention policy "somename" on "db" duration 4d'
             )
             # Test alter replication
             self.cli.alter_retention_policy('somename', 'db',
                                             replication=4)
             self.assertEqual(
                 m.last_request.qs['q'][0],
-                'alter retention policy somename on db replication 4'
+                'alter retention policy "somename" on "db" replication 4'
             )
 
             # Test alter default
@@ -623,7 +623,7 @@ class TestInfluxDBClient(unittest.TestCase):
                                             default=True)
             self.assertEqual(
                 m.last_request.qs['q'][0],
-                'alter retention policy somename on db default'
+                'alter retention policy "somename" on "db" default'
             )
 
     @raises(Exception)
@@ -644,7 +644,7 @@ class TestInfluxDBClient(unittest.TestCase):
             self.cli.drop_retention_policy('somename', 'db')
             self.assertEqual(
                 m.last_request.qs['q'][0],
-                'drop retention policy somename on db'
+                'drop retention policy "somename" on "db"'
             )
 
     @raises(Exception)


### PR DESCRIPTION
Original bug reported https://github.com/influxdata/influxdb-python/issues/320