### PR TITLE
Added escaping for backslash in value

### DIFF
--- a/influxdb/line_protocol.py
+++ b/influxdb/line_protocol.py
@@ -58,6 +58,8 @@ def _escape_value(value):
     if isinstance(value, text_type) and value != '':
         return "\"{0}\"".format(
             value.replace(
+                "\\", "\\\\"
+            ).replace(
                 "\"", "\\\""
             ).replace(
                 "\n", "\\n"


### PR DESCRIPTION
While you can safely do:

```
> insert escaping message="a\b"
> select * from escaping
name: escaping
--------------
time                    message
1464747108002387330     a\b
```

To insert the literal `a\b` in a field, if you wanted to insert something like `a\"b` (where the backslash here is not escaping the quotes). You have to insert it in influxdb like so:

```
> insert escaping message="a\\\"b"
> select * from escaping
name: escaping
--------------
time                    message
1464747191471814349     a\"b
```

With the current code, it would transform `a\"b` into `a\\"b` which then results in the following error:

```
ERR: {"error":"unable to parse 'escaping message=\"a\\\\\"b\"': unbalanced quotes"}
```

So escaping the blackslash should also be done and will not break the "a\b" case as seen here:

```
> insert escaping message="a\b"
> insert escaping message="a\\b"
> select * from escaping
name: escaping
--------------
time                    message
1464747338114619885     a\b
1464747340490499800     a\b
```

This was tested on 0.13.0-1
