### PR TITLE
Add get_list_privileges() to InfluxDBClient

### DIFF
--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -728,6 +728,28 @@ localhost:8086/databasename', timeout=5, udp_port=159)
                                                    username)
         self.query(text)
 
+    def get_list_privileges(self, username):
+        """Get the list of all privileges granted to given user.
+
+        :param username: the username to get privileges of
+        :type username: str
+
+        :returns: all privileges granted to given user
+        :rtype: list of dictionaries
+
+        :Example:
+
+        ::
+
+            >> privileges = client.get_list_privileges('user1')
+            >> privileges
+            [{u'privilege': u'WRITE', u'database': u'db1'},
+             {u'privilege': u'ALL PRIVILEGES', u'database': u'db2'},
+             {u'privilege': u'NO PRIVILEGES', u'database': u'db3'}]
+        """
+        text = "SHOW GRANTS FOR {0}".format(username)
+        return list(self.query(text).get_points())
+
     def send_packet(self, packet):
         """Send an UDP packet.
 

--- a/influxdb/tests/client_test.py
+++ b/influxdb/tests/client_test.py
@@ -776,6 +776,31 @@ class TestInfluxDBClient(unittest.TestCase):
         with _mocked_session(cli, 'get', 400):
             self.cli.revoke_privilege('', 'testdb', 'test')
 
+    def test_get_list_privileges(self):
+        data = {'results': [
+            {'series': [
+                {'columns': ['database', 'privilege'],
+                 'values': [
+                     ['db1', 'READ'],
+                     ['db2', 'ALL PRIVILEGES'],
+                     ['db3', 'NO PRIVILEGES']]}
+            ]}
+        ]}
+
+        with _mocked_session(self.cli, 'get', 200, json.dumps(data)):
+            self.assertListEqual(
+                self.cli.get_list_privileges('test'),
+                [{'database': 'db1', 'privilege': 'READ'},
+                 {'database': 'db2', 'privilege': 'ALL PRIVILEGES'},
+                 {'database': 'db3', 'privilege': 'NO PRIVILEGES'}]
+            )
+
+    @raises(Exception)
+    def test_get_list_privileges_fails(self):
+        cli = InfluxDBClient('host', 8086, 'username', 'password')
+        with _mocked_session(cli, 'get', 401):
+            cli.get_list_privileges('test')
+
     def test_invalid_port_fails(self):
         with self.assertRaises(ValueError):
             InfluxDBClient('host', '80/redir', 'username', 'password')


### PR DESCRIPTION
This allows library users to get a list of all privileges an InfluxDB
user has been granted.

One problematic aspect of this method is that, due to https://github.com/influxdata/influxdb/issues/4511 the interface of privilege related methods is inconsistent.

We could perform the normalisation (removal of elements with`NO PRIVILEGES` and `ALL PRIVILEGES` → `ALL`) in the Python library, but I would prefer to keep the library simple and to see this fixed this in InfluxDB itself.

On the other hand including it would probably lead to client code that performs the normalisation itself and that would have to be adapted once these inconsistencies have been resolved.