### PR TITLE
Add grant_admin_privileges() to InfluxDBClient

### DIFF
--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -684,6 +684,18 @@ localhost:8086/databasename', timeout=5, udp_port=159)
                                                    for k, v in tags.items()])
         self.query(query_str, database=database)
 
+    def grant_admin_privileges(self, username):
+        """Grant cluster administration privileges to a user.
+
+        :param username: the username to grant privileges to
+        :type username: str
+
+        .. note:: Only a cluster administrator can create/drop databases
+            and manage users.
+        """
+        text = "GRANT ALL PRIVILEGES TO {0}".format(username)
+        self.query(text)
+
     def revoke_admin_privileges(self, username):
         """Revoke cluster administration privileges from a user.
 

--- a/influxdb/tests/client_test.py
+++ b/influxdb/tests/client_test.py
@@ -710,6 +710,28 @@ class TestInfluxDBClient(unittest.TestCase):
 
             self.assertListEqual(self.cli.get_list_users(), [])
 
+    def test_grant_admin_privileges(self):
+        example_response = '{"results":[{}]}'
+
+        with requests_mock.Mocker() as m:
+            m.register_uri(
+                requests_mock.GET,
+                "http://localhost:8086/query",
+                text=example_response
+            )
+            self.cli.grant_admin_privileges('test')
+
+            self.assertEqual(
+                m.last_request.qs['q'][0],
+                'grant all privileges to test'
+            )
+
+    @raises(Exception)
+    def test_grant_admin_privileges_invalid(self):
+        cli = InfluxDBClient('host', 8086, 'username', 'password')
+        with _mocked_session(cli, 'get', 400):
+            self.cli.grant_admin_privileges('')
+
     def test_revoke_admin_privileges(self):
         example_response = '{"results":[{}]}'
 


### PR DESCRIPTION
This allows users to easily alter the 'admin' attribute of a user
account and complements the already existing 'revove_admin_privileges'
method.