### PR TITLE
Updated query method for v0.13 and later server.(#329)

### DIFF
--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -328,9 +328,13 @@ localhost:8086/databasename', timeout=5, udp_port=159)
         if epoch is not None:
             params['epoch'] = epoch
 
+        method = 'POST'
+        if query.split() and query.split()[0].upper() in ('SELECT', 'SHOW'):
+            method = 'GET'
+
         response = self.request(
             url="query",
-            method='GET',
+            method=method,
             params=params,
             data=None,
             expected_response_code=expected_response_code

--- a/influxdb/tests/client_test.py
+++ b/influxdb/tests/client_test.py
@@ -408,7 +408,7 @@ class TestInfluxDBClient(unittest.TestCase):
     def test_create_database(self):
         with requests_mock.Mocker() as m:
             m.register_uri(
-                requests_mock.GET,
+                requests_mock.POST,
                 "http://localhost:8086/query",
                 text='{"results":[{}]}'
             )
@@ -421,7 +421,7 @@ class TestInfluxDBClient(unittest.TestCase):
     def test_create_numeric_named_database(self):
         with requests_mock.Mocker() as m:
             m.register_uri(
-                requests_mock.GET,
+                requests_mock.POST,
                 "http://localhost:8086/query",
                 text='{"results":[{}]}'
             )
@@ -439,7 +439,7 @@ class TestInfluxDBClient(unittest.TestCase):
     def test_drop_database(self):
         with requests_mock.Mocker() as m:
             m.register_uri(
-                requests_mock.GET,
+                requests_mock.POST,
                 "http://localhost:8086/query",
                 text='{"results":[{}]}'
             )
@@ -452,7 +452,7 @@ class TestInfluxDBClient(unittest.TestCase):
     def test_drop_numeric_named_database(self):
         with requests_mock.Mocker() as m:
             m.register_uri(
-                requests_mock.GET,
+                requests_mock.POST,
                 "http://localhost:8086/query",
                 text='{"results":[{}]}'
             )
@@ -522,7 +522,7 @@ class TestInfluxDBClient(unittest.TestCase):
 
         with requests_mock.Mocker() as m:
             m.register_uri(
-                requests_mock.GET,
+                requests_mock.POST,
                 "http://localhost:8086/query",
                 text=example_response
             )
@@ -541,7 +541,7 @@ class TestInfluxDBClient(unittest.TestCase):
 
         with requests_mock.Mocker() as m:
             m.register_uri(
-                requests_mock.GET,
+                requests_mock.POST,
                 "http://localhost:8086/query",
                 text=example_response
             )
@@ -560,7 +560,7 @@ class TestInfluxDBClient(unittest.TestCase):
 
         with requests_mock.Mocker() as m:
             m.register_uri(
-                requests_mock.GET,
+                requests_mock.POST,
                 "http://localhost:8086/query",
                 text=example_response
             )
@@ -590,7 +590,7 @@ class TestInfluxDBClient(unittest.TestCase):
     @raises(Exception)
     def test_alter_retention_policy_invalid(self):
         cli = InfluxDBClient('host', 8086, 'username', 'password')
-        with _mocked_session(cli, 'get', 400):
+        with _mocked_session(cli, 'post', 400):
             self.cli.alter_retention_policy('somename', 'db')
 
     def test_drop_retention_policy(self):
@@ -598,7 +598,7 @@ class TestInfluxDBClient(unittest.TestCase):
 
         with requests_mock.Mocker() as m:
             m.register_uri(
-                requests_mock.GET,
+                requests_mock.POST,
                 "http://localhost:8086/query",
                 text=example_response
             )
@@ -715,7 +715,7 @@ class TestInfluxDBClient(unittest.TestCase):
 
         with requests_mock.Mocker() as m:
             m.register_uri(
-                requests_mock.GET,
+                requests_mock.POST,
                 "http://localhost:8086/query",
                 text=example_response
             )
@@ -729,7 +729,7 @@ class TestInfluxDBClient(unittest.TestCase):
     @raises(Exception)
     def test_grant_admin_privileges_invalid(self):
         cli = InfluxDBClient('host', 8086, 'username', 'password')
-        with _mocked_session(cli, 'get', 400):
+        with _mocked_session(cli, 'post', 400):
             self.cli.grant_admin_privileges('')
 
     def test_revoke_admin_privileges(self):
@@ -737,7 +737,7 @@ class TestInfluxDBClient(unittest.TestCase):
 
         with requests_mock.Mocker() as m:
             m.register_uri(
-                requests_mock.GET,
+                requests_mock.POST,
                 "http://localhost:8086/query",
                 text=example_response
             )
@@ -751,7 +751,7 @@ class TestInfluxDBClient(unittest.TestCase):
     @raises(Exception)
     def test_revoke_admin_privileges_invalid(self):
         cli = InfluxDBClient('host', 8086, 'username', 'password')
-        with _mocked_session(cli, 'get', 400):
+        with _mocked_session(cli, 'post', 400):
             self.cli.revoke_admin_privileges('')
 
     def test_grant_privilege(self):
@@ -759,7 +759,7 @@ class TestInfluxDBClient(unittest.TestCase):
 
         with requests_mock.Mocker() as m:
             m.register_uri(
-                requests_mock.GET,
+                requests_mock.POST,
                 "http://localhost:8086/query",
                 text=example_response
             )
@@ -773,7 +773,7 @@ class TestInfluxDBClient(unittest.TestCase):
     @raises(Exception)
     def test_grant_privilege_invalid(self):
         cli = InfluxDBClient('host', 8086, 'username', 'password')
-        with _mocked_session(cli, 'get', 400):
+        with _mocked_session(cli, 'post', 400):
             self.cli.grant_privilege('', 'testdb', 'test')
 
     def test_revoke_privilege(self):
@@ -781,7 +781,7 @@ class TestInfluxDBClient(unittest.TestCase):
 
         with requests_mock.Mocker() as m:
             m.register_uri(
-                requests_mock.GET,
+                requests_mock.POST,
                 "http://localhost:8086/query",
                 text=example_response
             )
@@ -795,7 +795,7 @@ class TestInfluxDBClient(unittest.TestCase):
     @raises(Exception)
     def test_revoke_privilege_invalid(self):
         cli = InfluxDBClient('host', 8086, 'username', 'password')
-        with _mocked_session(cli, 'get', 400):
+        with _mocked_session(cli, 'post', 400):
             self.cli.revoke_privilege('', 'testdb', 'test')
 
     def test_get_list_privileges(self):


### PR DESCRIPTION
`query` now uses `GET` for  `SELECT` or `SHOW` queries, and `POST` for others.
