### PR TITLE
Database removal/creation API changes

### DIFF
--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -465,16 +465,13 @@ localhost:8086/databasename', timeout=5, udp_port=159)
         """
         return list(self.query("SHOW DATABASES").get_points())
 
-    def create_database(self, dbname, if_not_exists=False):
+    def create_database(self, dbname):
         """Create a new database in InfluxDB.
 
         :param dbname: the name of the database to create
         :type dbname: str
         """
-        if if_not_exists:
-            self.query("CREATE DATABASE IF NOT EXISTS \"%s\"" % dbname)
-        else:
-            self.query("CREATE DATABASE \"%s\"" % dbname)
+        self.query("CREATE DATABASE \"%s\"" % dbname)
 
     def drop_database(self, dbname):
         """Drop a database from InfluxDB.

--- a/influxdb/tests/client_test.py
+++ b/influxdb/tests/client_test.py
@@ -418,19 +418,6 @@ class TestInfluxDBClient(unittest.TestCase):
                 'create database "new_db"'
             )
 
-    def test_create_database_with_exist_check(self):
-        with requests_mock.Mocker() as m:
-            m.register_uri(
-                requests_mock.GET,
-                "http://localhost:8086/query",
-                text='{"results":[{}]}'
-            )
-            self.cli.create_database('new_db', if_not_exists=True)
-            self.assertEqual(
-                m.last_request.qs['q'][0],
-                'create database if not exists "new_db"'
-            )
-
     def test_create_numeric_named_database(self):
         with requests_mock.Mocker() as m:
             m.register_uri(

--- a/influxdb/tests/client_test.py
+++ b/influxdb/tests/client_test.py
@@ -462,12 +462,6 @@ class TestInfluxDBClient(unittest.TestCase):
                 'drop database "123"'
             )
 
-    @raises(Exception)
-    def test_drop_database_fails(self):
-        cli = InfluxDBClient('host', 8086, 'username', 'password', 'db')
-        with _mocked_session(cli, 'delete', 401):
-            cli.drop_database('old_db')
-
     def test_get_list_database(self):
         data = {'results': [
             {'series': [

--- a/influxdb/tests/server_tests/client_test_with_server.py
+++ b/influxdb/tests/server_tests/client_test_with_server.py
@@ -147,12 +147,6 @@ class SimpleTests(SingleTestCaseWithServerMixin,
         self.assertIsNone(self.cli.drop_database('new_db_1'))
         self.assertEqual([{'name': 'new_db_2'}], self.cli.get_list_database())
 
-    def test_drop_database_fails(self):
-        with self.assertRaises(InfluxDBClientError) as ctx:
-            self.cli.drop_database('db')
-        self.assertIn('database not found: db',
-                      ctx.exception.content)
-
     def test_query_fail(self):
         with self.assertRaises(InfluxDBClientError) as ctx:
             self.cli.query('select column_one from foo')

--- a/influxdb/tests/server_tests/client_test_with_server.py
+++ b/influxdb/tests/server_tests/client_test_with_server.py
@@ -133,18 +133,6 @@ class SimpleTests(SingleTestCaseWithServerMixin,
             [{'name': 'new_db_1'}, {'name': 'new_db_2'}]
         )
 
-    def test_create_database_twice_if_not_exist(self):
-        self.assertIsNone(self.cli.create_database('new_db'))
-        self.assertIsNone(
-            self.cli.create_database('new_db', if_not_exists=True))
-
-    def test_create_database_twice_fails(self):
-        self.assertIsNone(self.cli.create_database('new_db'))
-        with self.assertRaises(InfluxDBClientError) as ctx:
-            self.cli.create_database('new_db')
-        self.assertEqual('database already exists',
-                         ctx.exception.content)
-
     def test_get_list_series_empty(self):
         rsp = self.cli.get_list_series()
         self.assertEqual([], rsp)

--- a/influxdb/tests/server_tests/client_test_with_server.py
+++ b/influxdb/tests/server_tests/client_test_with_server.py
@@ -199,16 +199,6 @@ class SimpleTests(SingleTestCaseWithServerMixin,
         rsp = list(self.cli.query("SHOW USERS")['results'])
         self.assertEqual(rsp, [])
 
-    def test_create_user_invalid_username(self):
-        with self.assertRaises(InfluxDBClientError) as ctx:
-            self.cli.create_user('very invalid', 'secret_password')
-        self.assertEqual(400, ctx.exception.code)
-        self.assertIn('{"error":"error parsing query: '
-                      'found invalid, expected WITH',
-                      ctx.exception.content)
-        rsp = list(self.cli.query("SHOW USERS")['results'])
-        self.assertEqual(rsp, [])
-
     def test_drop_user(self):
         self.cli.query("CREATE USER test WITH PASSWORD 'test'")
         self.cli.drop_user('test')


### PR DESCRIPTION
The API and sever behaviour regarding the creation and removal of databases changed. Most notably it is possible to run a create or drop database query multiple times without them raising an error.

This PR also introduces a breaking API change in that it removes the `if_not_exists` argument to `create_database`. We might not necessarily want to do it, but InfluxDB seem to plan deprecating that query parameter in 1.0 -- https://docs.influxdata.com/influxdb/v0.13/query_language/database_management/#create-a-database-with-create-database