### PR TITLE
Remove get_list_series

### DIFF
--- a/influxdb/_dataframe_client.py
+++ b/influxdb/_dataframe_client.py
@@ -90,20 +90,6 @@ class DataFrameClient(InfluxDBClient):
         else:
             return results
 
-    def get_list_series(self, database=None):
-        """
-        Get the list of series, in DataFrame
-
-        """
-        results = super(DataFrameClient, self)\
-            .query("SHOW SERIES", database=database)
-        if len(results):
-            return dict(
-                (key[0], pd.DataFrame(data)) for key, data in results.items()
-            )
-        else:
-            return {}
-
     def _to_dataframe(self, rs):
         result = {}
         if isinstance(rs, list):

--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -588,35 +588,6 @@ localhost:8086/databasename', timeout=5, udp_port=159)
         )
         return list(rsp.get_points())
 
-    def get_list_series(self, database=None):
-        """Get the list of series for a database.
-
-        :param database: the name of the database, defaults to the client's
-            current database
-        :type database: str
-        :returns: all series in the specified database
-        :rtype: list of dictionaries
-
-        :Example:
-
-        >> series = client.get_list_series('my_database')
-        >> series
-        [{'name': u'cpu_usage',
-          'tags': [{u'_id': 1,
-                    u'host': u'server01',
-                    u'region': u'us-west'}]}]
-        """
-        rsp = self.query("SHOW SERIES", database=database)
-        series = []
-        for serie in rsp.items():
-            series.append(
-                {
-                    "name": serie[0][0],
-                    "tags": list(serie[1])
-                }
-            )
-        return series
-
     def get_list_servers(self):
         """Get the list of servers in InfluxDB cluster.
 

--- a/influxdb/tests/client_test.py
+++ b/influxdb/tests/client_test.py
@@ -517,27 +517,6 @@ class TestInfluxDBClient(unittest.TestCase):
         with _mocked_session(cli, 'get', 401):
             cli.get_list_servers()
 
-    def test_get_list_series(self):
-        example_response = \
-            '{"results": [{"series": [{"name": "cpu_load_short", "columns": ' \
-            '["_id", "host", "region"], "values": ' \
-            '[[1, "server01", "us-west"]]}]}]}'
-
-        with requests_mock.Mocker() as m:
-            m.register_uri(
-                requests_mock.GET,
-                "http://localhost:8086/query",
-                text=example_response
-            )
-
-            self.assertListEqual(
-                self.cli.get_list_series(),
-                [{'name': 'cpu_load_short',
-                  'tags': [
-                      {'host': 'server01', '_id': 1, 'region': 'us-west'}
-                  ]}]
-            )
-
     def test_create_retention_policy_default(self):
         example_response = '{"results":[{}]}'
 

--- a/influxdb/tests/dataframe_client_test.py
+++ b/influxdb/tests/dataframe_client_test.py
@@ -301,49 +301,6 @@ class TestDataFrameClient(unittest.TestCase):
             result = cli.query('select column_one from foo;')
             self.assertEqual(result, {})
 
-    def test_list_series(self):
-        response = {
-            'results': [
-                {'series': [
-                    {
-                        'columns': ['host'],
-                        'measurement': 'cpu',
-                        'values': [
-                            ['server01']]
-                    },
-                    {
-                        'columns': [
-                            'host',
-                            'region'
-                        ],
-                        'measurement': 'network',
-                        'values': [
-                            [
-                                'server01',
-                                'us-west'
-                            ],
-                            [
-                                'server01',
-                                'us-east'
-                            ]
-                        ]
-                    }
-                ]}
-            ]
-        }
-
-        expected = {
-            'cpu': pd.DataFrame([['server01']], columns=['host']),
-            'network': pd.DataFrame(
-                [['server01', 'us-west'], ['server01', 'us-east']],
-                columns=['host', 'region'])}
-
-        cli = DataFrameClient('host', 8086, 'username', 'password', 'db')
-        with _mocked_session(cli, 'GET', 200, response):
-            series = cli.get_list_series()
-            assert_frame_equal(series['cpu'], expected['cpu'])
-            assert_frame_equal(series['network'], expected['network'])
-
     def test_get_list_database(self):
         data = {'results': [
             {'series': [

--- a/influxdb/tests/server_tests/client_test_with_server.py
+++ b/influxdb/tests/server_tests/client_test_with_server.py
@@ -133,15 +133,6 @@ class SimpleTests(SingleTestCaseWithServerMixin,
             [{'name': 'new_db_1'}, {'name': 'new_db_2'}]
         )
 
-    def test_get_list_series_empty(self):
-        rsp = self.cli.get_list_series()
-        self.assertEqual([], rsp)
-
-    @unittest.skip("Broken as of 0.9.0")
-    def test_get_list_series_empty_DF(self):
-        rsp = self.cliDF.get_list_series()
-        self.assertEqual({}, rsp)
-
     def test_drop_database(self):
         self.test_create_database()
         self.assertIsNone(self.cli.drop_database('new_db_1'))
@@ -449,43 +440,9 @@ class CommonTests(ManyTestCasesWithServerMixin,
         del example_object
         # TODO ?
 
-    def test_get_list_series_and_delete(self):
-        self.cli.write_points(dummy_point)
-        rsp = self.cli.get_list_series()
-        self.assertEqual(
-            [
-                {'name': 'cpu_load_short',
-                 'tags': [
-                     {'host': 'server01',
-                      'region': 'us-west',
-                      '_key':
-                          'cpu_load_short,host=server01,region=us-west'}]}
-            ],
-            rsp
-        )
-
     def test_delete_series_invalid(self):
         with self.assertRaises(InfluxDBClientError):
             self.cli.delete_series()
-
-    def test_delete_series(self):
-        self.assertEqual(len(self.cli.get_list_series()), 0)
-        self.cli.write_points(dummy_points)
-        self.assertEqual(len(self.cli.get_list_series()), 2)
-        self.cli.delete_series(measurement='cpu_load_short')
-        self.assertEqual(len(self.cli.get_list_series()), 1)
-        self.cli.delete_series(tags={'region': 'us-west'})
-        self.assertEqual(len(self.cli.get_list_series()), 0)
-
-    @unittest.skip("Broken as of 0.9.0")
-    def test_get_list_series_DF(self):
-        self.cli.write_points(dummy_point)
-        rsp = self.cliDF.get_list_series()
-
-        expected = pd.DataFrame(
-            [[1, 'server01', 'us-west']],
-            columns=['_id', 'host', 'region'])
-        assert_frame_equal(rsp['cpu_load_short'], expected)
 
     def test_default_retention_policy(self):
         rsp = self.cli.get_list_retention_policies()


### PR DESCRIPTION
SHOW SERIES returns data in line format since 0.11 and the current
functionality is broken. We have to implement a proper line format
parser before we can reintroduce this functionality.