### PR TITLE
Allow for dropping of the default retention policy

### DIFF
--- a/influxdb/tests/server_tests/client_test_with_server.py
+++ b/influxdb/tests/server_tests/client_test_with_server.py
@@ -604,16 +604,6 @@ class CommonTests(ManyTestCasesWithServerMixin,
             rsp
         )
 
-    def test_drop_retention_policy_default(self):
-        # Test drop default retention
-        with self.assertRaises(InfluxDBClientError) as ctx:
-            self.cli.drop_retention_policy('default', 'db')
-
-        self.assertEqual(400, ctx.exception.code)
-        self.assertIn(
-            '{"error":"error parsing query: found DEFAULT, expected POLICY',
-            ctx.exception.content)
-
     def test_issue_143(self):
         pt = partial(point, 'a_serie_name', timestamp='2015-03-30T16:16:37Z')
         pts = [


### PR DESCRIPTION
This no longer raises an error and simply results in no retention policy
being set for the database.