### PR TITLE
Adjustments to deal with time precision rounding errors in _convert_dataframe_to_json()

### DIFF
--- a/influxdb/_dataframe_client.py
+++ b/influxdb/_dataframe_client.py
@@ -142,7 +142,8 @@ class DataFrameClient(InfluxDBClient):
             {'measurement': measurement,
              'tags': tags if tags else {},
              'fields': rec,
-             'time': int(ts.value / precision_factor)
+             'time': ts.value if (precision_factor == 1)
+                else int(ts.value / precision_factor)
              }
             for ts, rec in zip(dataframe.index, dataframe.to_dict('record'))]
         return points


### PR DESCRIPTION
I believe this fixes issues [344](https://github.com/influxdata/influxdb-python/issues/344) and [340](https://github.com/influxdata/influxdb-python/issues/340) with timestamps rounding weirdly when nanosecond (or None) time precision is specified
