### PR TITLE
Fix DataFrameClient tag processing

### DIFF
--- a/influxdb/_dataframe_client.py
+++ b/influxdb/_dataframe_client.py
@@ -8,11 +8,11 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import math
-import re
 
 import pandas as pd
 
 from .client import InfluxDBClient
+from .line_protocol import _escape_tag
 
 
 def _pandas_time_unit(time_precision):
@@ -28,7 +28,7 @@ def _pandas_time_unit(time_precision):
 
 
 def _escape_pandas_series(s):
-    return s.apply(lambda v: re.escape(v))
+    return s.apply(lambda v: _escape_tag(v))
 
 
 class DataFrameClient(InfluxDBClient):


### PR DESCRIPTION
- tags should be sorted, with both global_tags and column_tags together
- tags values should be escaped
- reuse `line_protocol._escape_tag` for consistent escaping behaviour