### PR TITLE
Fix DataFrameClient import error on python3.5

### DIFF
--- a/influxdb/dataframe_client.py
+++ b/influxdb/dataframe_client.py
@@ -16,8 +16,10 @@ except ImportError as err:
     from .client import InfluxDBClient
 
     class DataFrameClient(InfluxDBClient):
+        err = err
+
         def __init__(self, *a, **kw):
             raise ImportError("DataFrameClient requires Pandas "
-                              "which couldn't be imported: %s" % err)
+                              "which couldn't be imported: %s" % self.err)
 else:
     from ._dataframe_client import DataFrameClient


### PR DESCRIPTION
Was getting `NameError: name 'err' is not defined` on python3.5. Stashing the error message inside the class seems to fix the problem.