### PR TITLE
remove pytz requirement as not used anymore

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 python-dateutil>=2.0.0
-pytz
 requests>=1.0.3
 six>=1.9.0


### PR DESCRIPTION
pytz does not seem to be imported anywhere in the code.
