### PR TITLE
make_line as separate from make_lines

### DIFF
--- a/influxdb/line_protocol.py
+++ b/influxdb/line_protocol.py
@@ -136,7 +136,7 @@ def make_line(measurement, tags=None, fields=None, time=None, precision=None):
     if field_list:
         line += ' ' + ','.join(field_list)
 
-    if time:
+    if time is not None:
         timestamp = _get_unicode(str(int(
             _convert_timestamp(time, precision)
         )))

--- a/influxdb/tests/test_line_protocol.py
+++ b/influxdb/tests/test_line_protocol.py
@@ -122,7 +122,7 @@ class TestLineProtocol(unittest.TestCase):
         )
 
 
-class Test_convert_timestamp(unittest.TestCase):
+class TestConvertTimestamp(unittest.TestCase):
 
     def test_if_raises_value_error_when_not_supported(self):
         with self.assertRaises(ValueError):

--- a/influxdb/tests/test_line_protocol.py
+++ b/influxdb/tests/test_line_protocol.py
@@ -10,6 +10,7 @@ import unittest
 from pytz import UTC, timezone
 
 from influxdb import line_protocol
+from influxdb.line_protocol import _convert_timestamp
 
 
 class TestLineProtocol(unittest.TestCase):
@@ -119,3 +120,14 @@ class TestLineProtocol(unittest.TestCase):
             line_protocol.quote_literal(r"""\foo ' bar " Örf"""),
             r"""'\\foo \' bar " Örf'"""
         )
+
+
+class Test_convert_timestamp(unittest.TestCase):
+
+    def test_if_raises_value_error_when_not_supported(self):
+        with self.assertRaises(ValueError):
+            _convert_timestamp(object())
+
+    def test_if_returs_unmodified_integral_values(self):
+        self.assertEqual(_convert_timestamp(5), 5)
+        self.assertEqual(_convert_timestamp(-2), -2)


### PR DESCRIPTION
Hi, extracted body of `make_lines` function to separate `make_line` function. Our input data has a bit different format than original function requires, therefore we couldn't use it. But it covers injection vulnerability.

Test cases fail because of pandas library deprecation warning.
