### PR TITLE
Add python 3.5 tests and drop 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,9 @@ addons:
     - wget
 env:
     - TOX_ENV=py27
-#    - TOX_ENV=py32
-# Disabling py32 tests until the following issue is fixed:
-# pip 8.x breaks python 3.2 compatibility
-# https://github.com/pypa/pip/issues/3390
     - TOX_ENV=py33
     - TOX_ENV=py34
+    - TOX_ENV=py35
     - TOX_ENV=pypy
     - TOX_ENV=pypy3
     - TOX_ENV=docs

--- a/README.rst
+++ b/README.rst
@@ -43,9 +43,7 @@ On Debian/Ubuntu, you can install it with this command::
 Dependencies
 ============
 
-The InfluxDB-Python distribution is supported and tested on Python 2.7, 3.3, 3.4, PyPy and PyPy3.
-
-**Note:** Python 3.2 is currently untested. See ``.travis.yml``. 
+The InfluxDB-Python distribution is supported and tested on Python 2.7, 3.3, 3.4, 3.5, PyPy, and PyPy3.
 
 Main dependency is:
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist = py34, py27, pypy, flake8
+envlist = py35, py34, py27, pypy, flake8
 
 [testenv]
 passenv = INFLUXDB_PYTHON_INFLUXD_PATH
 setenv = INFLUXDB_PYTHON_SKIP_SERVER_TESTS=False
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
-       py27,py32,py33,py34,py26: pandas
+       py27,py33,py34,py35: pandas
 # Only install pandas with non-pypy interpreters
 commands = nosetests -v --with-doctest {posargs}
 


### PR DESCRIPTION
Python 3.6 is around the corner, time to officially support Python 3.5.

Python 3.2 is out of support.  See https://www.python.org/dev/peps/pep-0392/#lifespan