### PR TITLE
Fix pandas calls + New test suite + Test against InfluxDB v1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ env:
 # Disabling py32 tests until the following issue is fixed:
 # pip 8.x breaks python 3.2 compatibility
 # https://github.com/pypa/pip/issues/3390
-    - TOX_ENV=py33
+#    - TOX_ENV=py33
+# pandas 0.19.x breaks python 3.3 compatibility
     - TOX_ENV=py34
     - TOX_ENV=pypy
     - TOX_ENV=pypy3

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,9 @@ addons:
 matrix:
   include:
     - python: 2.7
-      env: TOX_ENV=py27
-    - python: pypy
-      env: TOX_ENV=pypy
+    - python: pypy-5.3.1
     - python: 3.4
-      env: TOX_ENV=py34
-    - python: pypy3
-      env: TOX_ENV=pypy3
+    - python: pypy3.3-5.2-alpha1
     - python: 3.4
       env: TOX_ENV=docs
     - python: 3.4
@@ -31,11 +27,6 @@ install:
 script:
     - export INFLUXDB_PYTHON_INFLUXD_PATH=$(pwd)/influxdb_install/usr/bin/influxd
     - tox
-after_failure:
-    - cat /home/travis/build/influxdata/influxdb-python/.tox/coverage/log/coverage-0.log
-    - cat /home/travis/build/influxdata/influxdb-python/.tox/coverage/log/coverage-1.log
-    - cat /home/travis/build/influxdata/influxdb-python/.tox/docs/log/docs-0.log
-    - cat /home/travis/build/influxdata/influxdb-python/.tox/flake8/log/flake8-0.log
 after_success:
     - if [ "$TOX_ENV" == "coverage" ] ; then coveralls; fi
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,13 @@ addons:
 matrix:
   include:
     - python: 2.7
+      env: TOX_ENV=py27
     - python: pypy-5.3.1
+      env: TOX_ENV=pypy
     - python: 3.4
+      env: TOX_ENV=py34
     - python: pypy3.3-5.2-alpha1
+      env: TOX_ENV=pypy3
     - python: 3.4
       env: TOX_ENV=docs
     - python: 3.4
@@ -26,7 +30,7 @@ install:
     - dpkg -x influxdb*.deb influxdb_install
 script:
     - export INFLUXDB_PYTHON_INFLUXD_PATH=$(pwd)/influxdb_install/usr/bin/influxd
-    - tox
+    - tox -e $TOX_ENV
 after_success:
     - if [ "$TOX_ENV" == "coverage" ] ; then coveralls; fi
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,26 @@
 language: python
-python:
-    - "2.7"
-    - "3.4"
-    - "pypy"
-    - "pypy3"
+
 addons:
   apt:
     packages:
     - wget
-#env:
-#    - TOX_ENV=py27
-#    - TOX_ENV=py32
-# Disabling py32 tests until the following issue is fixed:
-# pip 8.x breaks python 3.2 compatibility
-# https://github.com/pypa/pip/issues/3390
-#    - TOX_ENV=py33
-# pandas 0.19.x breaks python 3.3 compatibility
-#    - TOX_ENV=py34
-#    - TOX_ENV=pypy
-#    - TOX_ENV=pypy3
-#    - TOX_ENV=docs
-#    - TOX_ENV=flake8
-#    - TOX_ENV=coverage
+
+matrix:
+  include:
+    - python: 2.7
+      env: TOX_ENV=py27
+    - python: pypy
+      env: TOX_ENV=pypy
+    - python: 3.4
+      env: TOX_ENV=py34
+    - python: pypy3
+      env: TOX_ENV=pypy3
+    - python: 2.7
+      env: TOX_ENV=docs
+    - python: 3.4
+      env: TOX_ENV=flake8
+    - python: 3.4
+      env: TOX_ENV=coverage
 
 install:
     - pip install tox
@@ -33,8 +32,7 @@ script:
     - export INFLUXDB_PYTHON_INFLUXD_PATH=$(pwd)/influxdb_install/usr/bin/influxd
     - tox
 after_success:
-    - sphinx-build -b html docs/source docs/build
-    - coveralls
+    - if [ "$TOX_ENV" == "coverage" ] ; then coveralls; fi
 notifications:
     email: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,10 @@ matrix:
       env: TOX_ENV=pypy
     - python: 3.4
       env: TOX_ENV=py34
-    - python: pypy3.3-5.2-alpha1
-      env: TOX_ENV=pypy3
+# An issue in travis-ci prevents this case from running
+# Link to issue: https://github.com/travis-ci/travis-ci/issues/6304
+#    - python: pypy3.3-5.2-alpha1
+#      env: TOX_ENV=pypy3
     - python: 3.4
       env: TOX_ENV=docs
     - python: 3.4
@@ -29,7 +31,6 @@ install:
     - wget https://dl.influxdata.com/influxdb/releases/influxdb_0.13.0_amd64.deb
     - dpkg -x influxdb*.deb influxdb_install
 script:
-    - if [ "$TOX_ENV" == "pypy3" ] ; then export VERSION=pypy3.3-5.2-alpha1; fi
     - export INFLUXDB_PYTHON_INFLUXD_PATH=$(pwd)/influxdb_install/usr/bin/influxd
     - tox -e $TOX_ENV
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ matrix:
   include:
     - python: 2.7
       env: TOX_ENV=py27
-    - python: 2.7
+    - python: pypy
       env: TOX_ENV=pypy
     - python: 3.4
       env: TOX_ENV=py34
-    - python: 3.4
+    - python: pypy3
       env: TOX_ENV=pypy3
     - python: 3.4
       env: TOX_ENV=docs
@@ -31,6 +31,11 @@ install:
 script:
     - export INFLUXDB_PYTHON_INFLUXD_PATH=$(pwd)/influxdb_install/usr/bin/influxd
     - tox
+after_failure:
+    - cat /home/travis/build/influxdata/influxdb-python/.tox/coverage/log/coverage-0.log
+    - cat /home/travis/build/influxdata/influxdb-python/.tox/coverage/log/coverage-1.log
+    - cat /home/travis/build/influxdata/influxdb-python/.tox/docs/log/docs-0.log
+    - cat /home/travis/build/influxdata/influxdb-python/.tox/flake8/log/flake8-0.log
 after_success:
     - if [ "$TOX_ENV" == "coverage" ] ; then coveralls; fi
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
     - pip install tox
     - pip install coveralls
     - mkdir influxdb_install
-    - wget https://dl.influxdata.com/influxdb/releases/influxdb_0.13.0_amd64.deb
+    - wget https://dl.influxdata.com/influxdb/releases/influxdb_1.1.0_amd64.deb
     - dpkg -x influxdb*.deb influxdb_install
 script:
     - export INFLUXDB_PYTHON_INFLUXD_PATH=$(pwd)/influxdb_install/usr/bin/influxd

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ install:
     - wget https://dl.influxdata.com/influxdb/releases/influxdb_0.13.0_amd64.deb
     - dpkg -x influxdb*.deb influxdb_install
 script:
+    - if [ "$TOX_ENV" == "pypy3" ] ; then export VERSION=pypy3.3-5.2-alpha1; fi
     - export INFLUXDB_PYTHON_INFLUXD_PATH=$(pwd)/influxdb_install/usr/bin/influxd
     - tox -e $TOX_ENV
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,13 @@ matrix:
   include:
     - python: 2.7
       env: TOX_ENV=py27
-    - python: pypy
+    - python: 2.7
       env: TOX_ENV=pypy
     - python: 3.4
       env: TOX_ENV=py34
-    - python: pypy3
+    - python: 3.4
       env: TOX_ENV=pypy3
-    - python: 2.7
+    - python: 3.4
       env: TOX_ENV=docs
     - python: 3.4
       env: TOX_ENV=flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: python
+python:
+    - "2.7"
+    - "3.4"
+    - "pypy3"
 addons:
   apt:
     packages:
@@ -17,6 +21,7 @@ env:
     - TOX_ENV=docs
     - TOX_ENV=flake8
     - TOX_ENV=coverage
+
 install:
     - pip install tox
     - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,25 +2,26 @@ language: python
 python:
     - "2.7"
     - "3.4"
+    - "pypy"
     - "pypy3"
 addons:
   apt:
     packages:
     - wget
-env:
-    - TOX_ENV=py27
+#env:
+#    - TOX_ENV=py27
 #    - TOX_ENV=py32
 # Disabling py32 tests until the following issue is fixed:
 # pip 8.x breaks python 3.2 compatibility
 # https://github.com/pypa/pip/issues/3390
 #    - TOX_ENV=py33
 # pandas 0.19.x breaks python 3.3 compatibility
-    - TOX_ENV=py34
-    - TOX_ENV=pypy
-    - TOX_ENV=pypy3
-    - TOX_ENV=docs
-    - TOX_ENV=flake8
-    - TOX_ENV=coverage
+#    - TOX_ENV=py34
+#    - TOX_ENV=pypy
+#    - TOX_ENV=pypy3
+#    - TOX_ENV=docs
+#    - TOX_ENV=flake8
+#    - TOX_ENV=coverage
 
 install:
     - pip install tox
@@ -32,7 +33,8 @@ script:
     - export INFLUXDB_PYTHON_INFLUXD_PATH=$(pwd)/influxdb_install/usr/bin/influxd
     - travis_wait 30 tox -e $TOX_ENV
 after_success:
-    - if [ "$TOX_ENV" == "coverage" ] ; then coveralls; fi
+    - sphinx-build -b html docs/source docs/build
+    - coveralls
 notifications:
     email: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
     - dpkg -x influxdb*.deb influxdb_install
 script:
     - export INFLUXDB_PYTHON_INFLUXD_PATH=$(pwd)/influxdb_install/usr/bin/influxd
-    - travis_wait 30 tox -e $TOX_ENV
+    - tox
 after_success:
     - sphinx-build -b html docs/source docs/build
     - coveralls

--- a/README.rst
+++ b/README.rst
@@ -22,10 +22,10 @@ InfluxDB is an open-source distributed time series database, find more about Inf
 
 .. _installation:
 
-InfluxDB v0.8.X users
-=====================
+InfluxDB pre v1.1.0 users
+=========================
 
-InfluxDB 0.9 was released and it is the new recommended version. However, InfluxDB 0.8.x users may still use the legacy client by using ``from influxdb.influxdb08 import InfluxDBClient`` instead.
+InfluxDB 1.1.0 was released and it is the new recommended version. InfluxDB 0.8.x users may still use the legacy client by using ``from influxdb.influxdb08 import InfluxDBClient`` instead.
 
 Installation
 ============

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ InfluxDB-Python is a client for interacting with InfluxDB_. Maintained by @aviau
     :alt: Documentation Status
 
 .. image:: https://img.shields.io/coveralls/influxdata/influxdb-python.svg
-  :target: https://coveralls.io/github/gansanay/influxdb-python
+  :target: https://coveralls.io/r/influxdata/influxdb-python
   :alt: Coverage
 
 .. _readme-about:

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ InfluxDB-Python is a client for interacting with InfluxDB_. Maintained by @aviau
     :alt: Documentation Status
 
 .. image:: https://img.shields.io/coveralls/influxdata/influxdb-python.svg
-  :target: https://coveralls.io/r/influxdata/influxdb-python
+  :target: https://coveralls.io/github/gansanay/influxdb-python
   :alt: Coverage
 
 .. _readme-about:

--- a/influxdb/_dataframe_client.py
+++ b/influxdb/_dataframe_client.py
@@ -273,8 +273,12 @@ class DataFrameClient(InfluxDBClient):
         }.get(time_precision, 1)
 
         # Make array of timestamp ints
-        time = ((dataframe.index.to_datetime().values.astype(int) /
-                 precision_factor).astype(int).astype(str))
+        if isinstance(dataframe.index, pd.tseries.period.PeriodIndex):
+            time = ((dataframe.index.to_timestamp().values.astype(int) /
+                     precision_factor).astype(int).astype(str))
+        else:
+            time = ((pd.to_datetime(dataframe.index).values.astype(int) /
+                     precision_factor).astype(int).astype(str))
 
         # If tag columns exist, make an array of formatted tag keys and values
         if tag_columns:

--- a/influxdb/influxdb08/dataframe_client.py
+++ b/influxdb/influxdb08/dataframe_client.py
@@ -132,7 +132,12 @@ class DataFrameClient(InfluxDBClient):
                 isinstance(dataframe.index, pd.tseries.index.DatetimeIndex)):
             raise TypeError('Must be DataFrame with DatetimeIndex or \
                             PeriodIndex.')
-        dataframe.index = dataframe.index.to_datetime()
+
+        if isinstance(dataframe.index, pd.tseries.period.PeriodIndex):
+            dataframe.index = dataframe.index.to_timestamp()
+        else:
+            dataframe.index = pd.to_datetime(dataframe.index)
+
         if dataframe.index.tzinfo is None:
             dataframe.index = dataframe.index.tz_localize('UTC')
         dataframe['time'] = [self._datetime_to_epoch(dt, time_precision)

--- a/influxdb/tests/server_tests/client_test_with_server.py
+++ b/influxdb/tests/server_tests/client_test_with_server.py
@@ -431,8 +431,8 @@ class CommonTests(ManyTestCasesWithServerMixin,
         rsp = self.cli.get_list_retention_policies()
         self.assertEqual(
             [
-                {'name': 'default',
-                 'duration': '0',
+                {'name': 'autogen',
+                 'duration': '0s',
                  'replicaN': 1,
                  'shardGroupDuration': u'168h0m0s',
                  'default': True}
@@ -447,11 +447,11 @@ class CommonTests(ManyTestCasesWithServerMixin,
 
         self.assertEqual(
             [
-                {'duration': '0',
+                {'duration': '0s',
                  'default': False,
                  'replicaN': 1,
                  'shardGroupDuration': u'168h0m0s',
-                 'name': 'default'},
+                 'name': 'autogen'},
                 {'duration': '24h0m0s',
                  'default': True,
                  'replicaN': 1,
@@ -471,11 +471,11 @@ class CommonTests(ManyTestCasesWithServerMixin,
         rsp = self.cli.get_list_retention_policies()
         self.assertEqual(
             [
-                {'duration': '0',
+                {'duration': '0s',
                  'default': True,
                  'replicaN': 1,
                  'shardGroupDuration': u'168h0m0s',
-                 'name': 'default'},
+                 'name': 'autogen'},
                 {'duration': '24h0m0s',
                  'default': False,
                  'replicaN': 1,
@@ -494,11 +494,11 @@ class CommonTests(ManyTestCasesWithServerMixin,
         rsp = self.cli.get_list_retention_policies()
         self.assertEqual(
             [
-                {'duration': '0',
+                {'duration': '0s',
                  'default': True,
                  'replicaN': 1,
                  'shardGroupDuration': u'168h0m0s',
-                 'name': 'default'},
+                 'name': 'autogen'},
                 {'duration': '96h0m0s',
                  'default': False,
                  'replicaN': 1,

--- a/influxdb/tests/server_tests/client_test_with_server.py
+++ b/influxdb/tests/server_tests/client_test_with_server.py
@@ -468,9 +468,9 @@ class CommonTests(ManyTestCasesWithServerMixin,
 
     def test_create_retention_policy(self):
         self.cli.create_retention_policy('somename', '1d', 1)
-        # NB: creating a retention policy without specifying shard group duration
+        # NB: creating a retention policy without specifying
+        # shard group duration
         #     leads to a shard group duration of 1 hour
-        # See https://docs.influxdata.com/influxdb/v1.1/query_language/database_management/#retention-policy-management
         rsp = self.cli.get_list_retention_policies()
         self.assertEqual(
             [

--- a/influxdb/tests/server_tests/client_test_with_server.py
+++ b/influxdb/tests/server_tests/client_test_with_server.py
@@ -468,6 +468,9 @@ class CommonTests(ManyTestCasesWithServerMixin,
 
     def test_create_retention_policy(self):
         self.cli.create_retention_policy('somename', '1d', 1)
+        # NB: creating a retention policy without specifying shard group duration
+        #     leads to a shard group duration of 1 hour
+        # See https://docs.influxdata.com/influxdb/v1.1/query_language/database_management/#retention-policy-management
         rsp = self.cli.get_list_retention_policies()
         self.assertEqual(
             [
@@ -491,6 +494,7 @@ class CommonTests(ManyTestCasesWithServerMixin,
         # Test alter duration
         self.cli.alter_retention_policy('somename', 'db',
                                         duration='4d')
+        # NB: altering retention policy doesn't change shard group duration
         rsp = self.cli.get_list_retention_policies()
         self.assertEqual(
             [
@@ -502,7 +506,7 @@ class CommonTests(ManyTestCasesWithServerMixin,
                 {'duration': '96h0m0s',
                  'default': False,
                  'replicaN': 1,
-                 'shardGroupDuration': u'24h0m0s',
+                 'shardGroupDuration': u'1h0m0s',
                  'name': 'somename'}
             ],
             rsp
@@ -511,6 +515,7 @@ class CommonTests(ManyTestCasesWithServerMixin,
         # Test alter replication
         self.cli.alter_retention_policy('somename', 'db',
                                         replication=4)
+        # NB: altering retention policy doesn't change shard group duration
         rsp = self.cli.get_list_retention_policies()
         self.assertEqual(
             [
@@ -522,7 +527,7 @@ class CommonTests(ManyTestCasesWithServerMixin,
                 {'duration': '96h0m0s',
                  'default': False,
                  'replicaN': 4,
-                 'shardGroupDuration': u'24h0m0s',
+                 'shardGroupDuration': u'1h0m0s',
                  'name': 'somename'}
             ],
             rsp
@@ -531,6 +536,7 @@ class CommonTests(ManyTestCasesWithServerMixin,
         # Test alter default
         self.cli.alter_retention_policy('somename', 'db',
                                         default=True)
+        # NB: altering retention policy doesn't change shard group duration
         rsp = self.cli.get_list_retention_policies()
         self.assertEqual(
             [
@@ -542,7 +548,7 @@ class CommonTests(ManyTestCasesWithServerMixin,
                 {'duration': '96h0m0s',
                  'default': True,
                  'replicaN': 4,
-                 'shardGroupDuration': u'24h0m0s',
+                 'shardGroupDuration': u'1h0m0s',
                  'name': 'somename'}
             ],
             rsp

--- a/influxdb/tests/server_tests/client_test_with_server.py
+++ b/influxdb/tests/server_tests/client_test_with_server.py
@@ -514,11 +514,11 @@ class CommonTests(ManyTestCasesWithServerMixin,
         rsp = self.cli.get_list_retention_policies()
         self.assertEqual(
             [
-                {'duration': '0',
+                {'duration': '0s',
                  'default': True,
                  'replicaN': 1,
                  'shardGroupDuration': u'168h0m0s',
-                 'name': 'default'},
+                 'name': 'autogen'},
                 {'duration': '96h0m0s',
                  'default': False,
                  'replicaN': 4,
@@ -534,11 +534,11 @@ class CommonTests(ManyTestCasesWithServerMixin,
         rsp = self.cli.get_list_retention_policies()
         self.assertEqual(
             [
-                {'duration': '0',
+                {'duration': '0s',
                  'default': False,
                  'replicaN': 1,
                  'shardGroupDuration': u'168h0m0s',
-                 'name': 'default'},
+                 'name': 'autogen'},
                 {'duration': '96h0m0s',
                  'default': True,
                  'replicaN': 4,
@@ -558,11 +558,11 @@ class CommonTests(ManyTestCasesWithServerMixin,
         rsp = self.cli.get_list_retention_policies()
         self.assertEqual(
             [
-                {'duration': '0',
+                {'duration': '0s',
                  'default': True,
                  'replicaN': 1,
                  'shardGroupDuration': u'168h0m0s',
-                 'name': 'default'},
+                 'name': 'autogen'},
                 {'duration': '24h0m0s',
                  'default': False,
                  'replicaN': 1,
@@ -580,11 +580,11 @@ class CommonTests(ManyTestCasesWithServerMixin,
         rsp = self.cli.get_list_retention_policies()
         self.assertEqual(
             [
-                {'duration': '0',
+                {'duration': '0s',
                  'default': True,
                  'replicaN': 1,
                  'shardGroupDuration': u'168h0m0s',
-                 'name': 'default'}
+                 'name': 'autogen'}
             ],
             rsp
         )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,8 @@
 [tox]
-envlist = py34, py27, pypy, flake8
+envlist = py34, py27, pypy, pypy3, flake8
+
+[tox:travis]
+3.4 = py34, pypy3
 
 [testenv]
 passenv = INFLUXDB_PYTHON_INFLUXD_PATH

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-#envlist = py34, py27, pypy, pypy3, flake8
+envlist = py27, py34, pypy, pypy3, flake8, coverage, docs
 
 [testenv]
 passenv = INFLUXDB_PYTHON_INFLUXD_PATH
 setenv = INFLUXDB_PYTHON_SKIP_SERVER_TESTS=False
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
-       py27,py32,py34,py26: pandas
+       py27,py34: pandas
 # Only install pandas with non-pypy interpreters
 commands = nosetests -v --with-doctest {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34, py27, pypy, pypy3, flake8
+#envlist = py34, py27, pypy, pypy3, flake8
 
 [tox:travis]
 3.4 = py34, pypy3
@@ -9,7 +9,7 @@ passenv = INFLUXDB_PYTHON_INFLUXD_PATH
 setenv = INFLUXDB_PYTHON_SKIP_SERVER_TESTS=False
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
-       py27,py32,py33,py34,py26: pandas
+       py27,py32,py34,py26: pandas
 # Only install pandas with non-pypy interpreters
 commands = nosetests -v --with-doctest {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,6 @@
 [tox]
 #envlist = py34, py27, pypy, pypy3, flake8
 
-[tox:travis]
-3.4 = py34, pypy3
-
 [testenv]
 passenv = INFLUXDB_PYTHON_INFLUXD_PATH
 setenv = INFLUXDB_PYTHON_SKIP_SERVER_TESTS=False


### PR DESCRIPTION
Fixes #358, #376, #384, #387 
Includes #385 

Changelog:
* pandas deprecated .to_datetime() calls are fixed
* dropped support of python < 3.4 to support pandas >= 0.19
* server tests are done with the latest release of influxdb : 1.1.0, fix tests due to version change
* new Travis CI test matrix (there is an issue with testing for pypy)