### PR TITLE
Fix for from_DSN() constructor when using DataFrameClient

### DIFF
--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -131,8 +131,8 @@ class InfluxDBClient(object):
     def _get_port(self):
         return self.__port
 
-    @staticmethod
-    def from_DSN(dsn, **kwargs):
+    @classmethod
+    def from_DSN(cls, dsn, **kwargs):
         """Return an instance of :class:`~.InfluxDBClient` from the provided
         data source name. Supported schemes are "influxdb", "https+influxdb"
         and "udp+influxdb". Parameters for the :class:`~.InfluxDBClient`
@@ -169,7 +169,7 @@ localhost:8086/databasename', timeout=5, udp_port=159)
         init_args['port'] = port
         init_args.update(kwargs)
 
-        return InfluxDBClient(**init_args)
+        return cls(**init_args)
 
     def switch_database(self, database):
         """Change the client's database.

--- a/influxdb/tests/dataframe_client_test.py
+++ b/influxdb/tests/dataframe_client_test.py
@@ -553,3 +553,8 @@ class TestDataFrameClient(unittest.TestCase):
             cli._datetime_to_epoch(timestamp, time_precision='n'),
             1356998400000000000.0
         )
+
+    def test_dsn_constructor(self):
+        client = DataFrameClient.from_DSN('influxdb://localhost:8086')
+        self.assertIsInstance(client, DataFrameClient)
+        self.assertEqual('http://localhost:8086', client._baseurl)


### PR DESCRIPTION
When creating an instance of `DataFrameClient` using the `from_DSN()` constructor, an instance of `InfluxDBClient` is returned instead. This change returns the correct instance type.

See also issue #381 