### PR TITLE
Space padded select-queries should return DataFrames

### DIFF
--- a/influxdb/_dataframe_client.py
+++ b/influxdb/_dataframe_client.py
@@ -140,7 +140,7 @@ class DataFrameClient(InfluxDBClient):
 
         """
         results = super(DataFrameClient, self).query(query, database=database)
-        if query.upper().startswith("SELECT"):
+        if query.strip().upper().startswith("SELECT"):
             if len(results) > 0:
                 return self._to_dataframe(results)
             else:


### PR DESCRIPTION
Fixed an issue where space padded select-queries are interpreted as being non-select-queries thus falling back to returning a ResultSet instead of a dictionary of panda DataFrames.