### PR TITLE
[Ready for Review] Chunked query responses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ addons:
     - wget
 
 matrix:
+  allow_failures:
+    - python: 3.4
+      env: TOX_ENV=docs
   include:
     - python: 2.7
       env: TOX_ENV=py27

--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -295,7 +295,6 @@ localhost:8086/databasename', timeout=5, udp_port=159)
 
     def _read_chunked_response(self, response, raise_errors=True):
         for line in response.iter_lines():
-            # import ipdb; ipdb.set_trace()
             if isinstance(line, bytes):
                 line = line.decode('utf-8')
             data = json.loads(line)
@@ -328,6 +327,11 @@ localhost:8086/databasename', timeout=5, udp_port=159)
         :param raise_errors: Whether or not to raise exceptions when InfluxDB
             returns errors, defaults to True
         :type raise_errors: bool
+
+        :param chunked: Enable to use chunked responses from InfluxDB.
+            With ``chunked`` enabled, a _generator_ of ResultSet objects
+            is returned as opposed to a list.
+        :type chunked: bool
 
         :returns: the queried data
         :rtype: :class:`~.ResultSet`

--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -308,7 +308,8 @@ localhost:8086/databasename', timeout=5, udp_port=159)
               expected_response_code=200,
               database=None,
               raise_errors=True,
-              chunked=False):
+              chunked=False,
+              chunk_size=0):
         """Send a query to InfluxDB.
 
         :param query: the actual query string
@@ -333,6 +334,9 @@ localhost:8086/databasename', timeout=5, udp_port=159)
             is returned as opposed to a list.
         :type chunked: bool
 
+        :param chunk_size: Size of each chunk to tell InfluxDB to use.
+        :type chunk_size: int
+
         :returns: the queried data
         :rtype: :class:`~.ResultSet`
         """
@@ -355,6 +359,8 @@ localhost:8086/databasename', timeout=5, udp_port=159)
 
         if chunked or 'chunked' in params:
             params['chunked'] = 'true'
+            if chunk_size > 0:
+                params['chunk_size'] = chunk_size
             return self._read_chunked_response(response)
 
         data = response.json()

--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -349,6 +349,11 @@ localhost:8086/databasename', timeout=5, udp_port=159)
         if epoch is not None:
             params['epoch'] = epoch
 
+        if chunked:
+            params['chunked'] = 'true'
+            if chunk_size > 0:
+                params['chunk_size'] = chunk_size
+
         response = self.request(
             url="query",
             method='GET',
@@ -357,10 +362,7 @@ localhost:8086/databasename', timeout=5, udp_port=159)
             expected_response_code=expected_response_code
         )
 
-        if chunked or 'chunked' in params:
-            params['chunked'] = 'true'
-            if chunk_size > 0:
-                params['chunk_size'] = chunk_size
+        if chunked:
             return self._read_chunked_response(response)
 
         data = response.json()

--- a/influxdb/tests/client_test.py
+++ b/influxdb/tests/client_test.py
@@ -812,22 +812,23 @@ class TestInfluxDBClient(unittest.TestCase):
                 "http://localhost:8086/query",
                 text=example_response
             )
-            response = list(self.cli.query('show series limit 4 offset 0',
-                                           chunked=True, chunk_size=4))
+            response = self.cli.query('show series limit 4 offset 0',
+                                      chunked=True, chunk_size=4)
             self.assertTrue(len(response) == 4)
-            self.assertEqual(response[0].raw, ResultSet(
-                {"statement_id": 0,
-                 "series": [{"name": "cpu",
-                             "columns": ["fieldKey", "fieldType"],
-                             "values": [["value", "integer"]]}],
-                 "partial": True}
-            ).raw)
-            self.assertEqual(response[3].raw, ResultSet(
-                {"statement_id": 0,
-                 "series": [{"name": "memory",
-                             "columns": ["fieldKey", "fieldType"],
-                             "values": [["value", "integer"]]}]}
-            ).raw)
+            self.assertEqual(response.__repr__(), ResultSet(
+                {'series': [{'values': [['value', 'integer']],
+                             'name': 'cpu',
+                             'columns': ['fieldKey', 'fieldType']},
+                            {'values': [['value', 'integer']],
+                             'name': 'iops',
+                             'columns': ['fieldKey', 'fieldType']},
+                            {'values': [['value', 'integer']],
+                             'name': 'load',
+                             'columns': ['fieldKey', 'fieldType']},
+                            {'values': [['value', 'integer']],
+                             'name': 'memory',
+                             'columns': ['fieldKey', 'fieldType']}]}
+            ).__repr__())
 
 
 class FakeClient(InfluxDBClient):

--- a/influxdb/tests/client_test.py
+++ b/influxdb/tests/client_test.py
@@ -813,7 +813,7 @@ class TestInfluxDBClient(unittest.TestCase):
                 text=example_response
             )
             response = list(self.cli.query('show series limit 4 offset 0',
-                                           chunked=True))
+                                           chunked=True, chunk_size=4))
             self.assertTrue(len(response) == 4)
             self.assertEqual(response[0].raw, ResultSet(
                 {"statement_id": 0,

--- a/influxdb/tests/client_test.py
+++ b/influxdb/tests/client_test.py
@@ -34,6 +34,7 @@ import unittest
 from influxdb import InfluxDBClient
 from influxdb.resultset import ResultSet
 
+
 def _build_response_object(status_code=200, content=""):
     resp = requests.Response()
     resp.status_code = status_code
@@ -793,16 +794,17 @@ class TestInfluxDBClient(unittest.TestCase):
             InfluxDBClient('host', '80/redir', 'username', 'password')
 
     def test_chunked_response(self):
-        example_response = u'{"results":[{"statement_id":0,"series": ' \
-          '[{"name":"cpu","columns":["fieldKey","fieldType"],"values":' \
-          '[["value","integer"]]}],"partial":true}]}\n{"results":' \
-          '[{"statement_id":0,"series":[{"name":"iops","columns":' \
-          '["fieldKey","fieldType"],"values":[["value","integer"]]}],' \
-          '"partial":true}]}\n{"results":[{"statement_id":0,"series":' \
-          '[{"name":"load","columns":["fieldKey","fieldType"],"values":' \
-          '[["value","integer"]]}],"partial":true}]}\n{"results":' \
-          '[{"statement_id":0,"series":[{"name":"memory","columns":' \
-          '["fieldKey","fieldType"],"values":[["value","integer"]]}]}]}\n'
+        example_response = \
+            u'{"results":[{"statement_id":0,"series":' \
+            '[{"name":"cpu","columns":["fieldKey","fieldType"],"values":' \
+            '[["value","integer"]]}],"partial":true}]}\n{"results":' \
+            '[{"statement_id":0,"series":[{"name":"iops","columns":' \
+            '["fieldKey","fieldType"],"values":[["value","integer"]]}],' \
+            '"partial":true}]}\n{"results":[{"statement_id":0,"series":' \
+            '[{"name":"load","columns":["fieldKey","fieldType"],"values":' \
+            '[["value","integer"]]}],"partial":true}]}\n{"results":' \
+            '[{"statement_id":0,"series":[{"name":"memory","columns":' \
+            '["fieldKey","fieldType"],"values":[["value","integer"]]}]}]}\n'
 
         with requests_mock.Mocker() as m:
             m.register_uri(
@@ -810,19 +812,23 @@ class TestInfluxDBClient(unittest.TestCase):
                 "http://localhost:8086/query",
                 text=example_response
             )
-            response = list(self.cli.query('show series limit 4 offset 0', chunked=True))
+            response = list(self.cli.query('show series limit 4 offset 0',
+                                           chunked=True))
             self.assertTrue(len(response) == 4)
             self.assertEqual(response[0].raw, ResultSet(
-                {"statement_id":0,
-                 "series": [{"name":"cpu","columns":["fieldKey","fieldType"],
-                             "values": [["value","integer"]]}],"partial":True}
-                ).raw)
+                {"statement_id": 0,
+                 "series": [{"name": "cpu",
+                             "columns": ["fieldKey", "fieldType"],
+                             "values": [["value", "integer"]]}],
+                 "partial": True}
+            ).raw)
             self.assertEqual(response[3].raw, ResultSet(
-                {"statement_id":0,
-                 "series":[{"name":"memory","columns":
-                            ["fieldKey","fieldType"],
-                            "values":[["value","integer"]]}]}
-                ).raw)
+                {"statement_id": 0,
+                 "series": [{"name": "memory",
+                             "columns": ["fieldKey", "fieldType"],
+                             "values": [["value", "integer"]]}]}
+            ).raw)
+
 
 class FakeClient(InfluxDBClient):
 


### PR DESCRIPTION
Changes:

* Added `chunked` and `chunk_size` keyword arguments to InfluxDBClient.query
* Added chunked response parsing of queries and chunked response test
* Added allow failure on docs for travis-ci

`query` doc strings now indicate that with `chunked=True` a _generator_ of `ResultSet` objects is returned as opposed to a list.

On latest master branch trying to use chunked responses by setting `params={'chunked': 'true'}` would result in JSON parse failure.