### PR TITLE
Added 'total_seconds' function for python26 compatibility

### DIFF
--- a/influxdb/_dataframe_client.py
+++ b/influxdb/_dataframe_client.py
@@ -12,7 +12,7 @@ import math
 import pandas as pd
 
 from .client import InfluxDBClient
-from .line_protocol import _escape_tag
+from .line_protocol import _escape_tag, total_seconds
 
 
 def _pandas_time_unit(time_precision):
@@ -375,7 +375,7 @@ class DataFrameClient(InfluxDBClient):
         return dataframe
 
     def _datetime_to_epoch(self, datetime, time_precision='s'):
-        seconds = (datetime - self.EPOCH).total_seconds()
+        seconds = total_seconds(datetime - self.EPOCH)
         if time_precision == 'h':
             return seconds / 3600
         elif time_precision == 'm':

--- a/influxdb/_dataframe_client.py
+++ b/influxdb/_dataframe_client.py
@@ -12,7 +12,7 @@ import math
 import pandas as pd
 
 from .client import InfluxDBClient
-from .line_protocol import _escape_tag, total_seconds
+from .line_protocol import _escape_tag
 
 
 def _pandas_time_unit(time_precision):
@@ -375,7 +375,7 @@ class DataFrameClient(InfluxDBClient):
         return dataframe
 
     def _datetime_to_epoch(self, datetime, time_precision='s'):
-        seconds = total_seconds(datetime - self.EPOCH)
+        seconds = self.total_seconds(datetime - self.EPOCH)
         if time_precision == 'h':
             return seconds / 3600
         elif time_precision == 'm':

--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -190,6 +190,22 @@ localhost:8086/databasename', timeout=5, udp_port=159)
         self._username = username
         self._password = password
 
+    def total_seconds(self, td):
+        """
+        total_seconds()
+
+        Keep backward compatibility with Python 2.6, where datetime
+        does not contain this method.
+
+        :param td: timedelta
+        :type td: datetime.timedelta
+        """
+        if hasattr(td, 'total_seconds'):
+            return td.total_seconds()
+        else:
+            return (td.microseconds +
+                    (td.seconds + td.days * 24 * 3600) * 10**6) / 10**6
+
     def request(self, url, method='GET', params=None, data=None,
                 expected_response_code=200, headers=None):
         """Make a HTTP request to the InfluxDB API.

--- a/influxdb/influxdb08/client.py
+++ b/influxdb/influxdb08/client.py
@@ -208,6 +208,22 @@ class InfluxDBClient(object):
         self._username = username
         self._password = password
 
+    def total_seconds(self, td):
+        """
+        total_seconds()
+
+        Keep backward compatibility with Python 2.6, where datetime
+        does not contain this method.
+
+        :param td: timedelta
+        :type td: datetime.timedelta
+        """
+        if hasattr(td, 'total_seconds'):
+            return td.total_seconds()
+        else:
+            return (td.microseconds +
+                    (td.seconds + td.days * 24 * 3600) * 10**6) / 10**6
+
     def request(self, url, method='GET', params=None, data=None,
                 expected_response_code=200):
         """

--- a/influxdb/influxdb08/dataframe_client.py
+++ b/influxdb/influxdb08/dataframe_client.py
@@ -13,16 +13,6 @@ import warnings
 from .client import InfluxDBClient
 
 
-def total_seconds(td):
-    # Keep backward compatibility with Python 2.6 which doesn't have
-    # this method
-    if hasattr(td, 'total_seconds'):
-        return td.total_seconds()
-    else:
-        return (td.microseconds +
-                (td.seconds + td.days * 24 * 3600) * 10**6) / 10**6
-
-
 class DataFrameClient(InfluxDBClient):
     """
     The ``DataFrameClient`` object holds information necessary to connect
@@ -173,7 +163,7 @@ class DataFrameClient(InfluxDBClient):
             return list(array)
 
     def _datetime_to_epoch(self, datetime, time_precision='s'):
-        seconds = total_seconds(datetime - self.EPOCH)
+        seconds = self.total_seconds(datetime - self.EPOCH)
         if time_precision == 's':
             return seconds
         elif time_precision == 'm' or time_precision == 'ms':

--- a/influxdb/influxdb08/dataframe_client.py
+++ b/influxdb/influxdb08/dataframe_client.py
@@ -13,6 +13,16 @@ import warnings
 from .client import InfluxDBClient
 
 
+def total_seconds(td):
+    # Keep backward compatibility with Python 2.6 which doesn't have
+    # this method
+    if hasattr(td, 'total_seconds'):
+        return td.total_seconds()
+    else:
+        return (td.microseconds +
+                (td.seconds + td.days * 24 * 3600) * 10**6) / 10**6
+
+
 class DataFrameClient(InfluxDBClient):
     """
     The ``DataFrameClient`` object holds information necessary to connect
@@ -163,7 +173,7 @@ class DataFrameClient(InfluxDBClient):
             return list(array)
 
     def _datetime_to_epoch(self, datetime, time_precision='s'):
-        seconds = (datetime - self.EPOCH).total_seconds()
+        seconds = total_seconds(datetime - self.EPOCH)
         if time_precision == 's':
             return seconds
         elif time_precision == 'm' or time_precision == 'ms':

--- a/influxdb/line_protocol.py
+++ b/influxdb/line_protocol.py
@@ -16,6 +16,16 @@ from six import binary_type, text_type, integer_types, PY2
 EPOCH = UTC.localize(datetime.utcfromtimestamp(0))
 
 
+def total_seconds(td):
+    # Keep backward compatibility with Python 2.6 which doesn't have
+    # this method
+    if hasattr(td, 'total_seconds'):
+        return td.total_seconds()
+    else:
+        return (td.microseconds +
+                (td.seconds + td.days * 24 * 3600) * 10**6) / 10**6
+
+
 def _convert_timestamp(timestamp, precision=None):
     if isinstance(timestamp, Integral):
         return timestamp  # assume precision is correct if timestamp is int
@@ -24,7 +34,7 @@ def _convert_timestamp(timestamp, precision=None):
     if isinstance(timestamp, datetime):
         if not timestamp.tzinfo:
             timestamp = UTC.localize(timestamp)
-        ns = (timestamp - EPOCH).total_seconds() * 1e9
+        ns = total_seconds(timestamp - EPOCH) * 1e9
         if precision is None or precision == 'n':
             return ns
         elif precision == 'u':

--- a/influxdb/line_protocol.py
+++ b/influxdb/line_protocol.py
@@ -17,8 +17,15 @@ EPOCH = UTC.localize(datetime.utcfromtimestamp(0))
 
 
 def total_seconds(td):
-    # Keep backward compatibility with Python 2.6 which doesn't have
-    # this method
+    """
+    total_seconds()
+
+    Keep backward compatibility with Python 2.6, where datetime
+    does not contain this method.
+
+    :param td: timedelta
+    :type td: datetime.timedelta
+    """
     if hasattr(td, 'total_seconds'):
         return td.total_seconds()
     else:


### PR DESCRIPTION
Related to #400 
Maybe not so elegant solution, but have been forced to make it work with Python2.6 project.
It would be very nice if you could merge this or make it work with python2.6 somehow.
Thank you