### PR TITLE
fix for lost precision on float field values

### DIFF
--- a/influxdb/line_protocol.py
+++ b/influxdb/line_protocol.py
@@ -75,12 +75,22 @@ def quote_literal(value):
     )
 
 
+def _is_float(value):
+    try:
+        float(value)
+    except ValueError:
+        return False
+    return True
+
+
 def _escape_value(value):
     value = _get_unicode(value)
     if isinstance(value, text_type) and value != '':
         return quote_ident(value)
     elif isinstance(value, integer_types) and not isinstance(value, bool):
         return str(value) + 'i'
+    elif _is_float(value):
+        return repr(value)
     else:
         return str(value)
 

--- a/influxdb/tests/test_line_protocol.py
+++ b/influxdb/tests/test_line_protocol.py
@@ -119,3 +119,19 @@ class TestLineProtocol(unittest.TestCase):
             line_protocol.quote_literal(r"""\foo ' bar " Örf"""),
             r"""'\\foo \' bar " Örf'"""
         )
+
+    def test_float_with_long_decimal_fraction(self):
+        data = {
+            "points": [
+                {
+                    "measurement": "test",
+                    "fields": {
+                        "float_val": 1.0000000000000009,
+                    }
+                }
+            ]
+        }
+        self.assertEqual(
+            line_protocol.make_lines(data),
+            'test float_val=1.0000000000000009\n'
+        )

--- a/influxdb/tests/test_line_protocol.py
+++ b/influxdb/tests/test_line_protocol.py
@@ -121,6 +121,7 @@ class TestLineProtocol(unittest.TestCase):
         )
 
     def test_float_with_long_decimal_fraction(self):
+        """Ensure precision is preserved when casting floats into strings."""
         data = {
             "points": [
                 {


### PR DESCRIPTION
use `repr()` instead of `str()` when casting floats into strings so that `float(repr(my_float)) == my_float` can be guaranteed, which is not the case when using `str()`