### PR TITLE
fix the bug of function get_points when with tags parameters

### DIFF
--- a/influxdb/resultset.py
+++ b/influxdb/resultset.py
@@ -106,7 +106,7 @@ class ResultSet(object):
                 # we will matches every returned serie
                 serie_tags = serie.get('columns', {})
                 for item in self._get_points_for_serie(serie):
-                    if tags is None or self._tag_matches(item, tags):   
+                    if tags is None or self._tag_matches(item, tags):
                         yield item
 
     def __repr__(self):

--- a/influxdb/resultset.py
+++ b/influxdb/resultset.py
@@ -104,9 +104,9 @@ class ResultSet(object):
             elif measurement in (None, serie_name):
                 # by default if no tags was provided then
                 # we will matches every returned serie
-                serie_tags = serie.get('tags', {})
-                if tags is None or self._tag_matches(serie_tags, tags):
-                    for item in self._get_points_for_serie(serie):
+                serie_tags = serie.get('columns', {})
+                for item in self._get_points_for_serie(serie):
+                    if tags is None or self._tag_matches(item, tags):   
                         yield item
 
     def __repr__(self):


### PR DESCRIPTION


when i used influxdb-python to query with tags as follows, the result showed nothing
```
result = client.query('select * from cpu limit 100;')
for p in list(result.get_points( measurement='cpu', tags={"host":"10.12.0.99"} )):
      print p
```

so, i checked the function of get_points and the function _tag_matches, then i found two errors in get_points
 
* 1.change serie.get('`tags`', {}) to serie.get('`columns`', {}) 
* 2.move condition judgement line which invoke _tag_matches  into for loop, and change `serie_tags` to `item`
```
 -                serie_tags = serie.get('tags', {})
 -                if tags is None or self._tag_matches(serie_tags, tags):
 -                    for item in self._get_points_for_serie(serie):
 +                serie_tags = serie.get('columns', {})
 +                for item in self._get_points_for_serie(serie):
 +                    if tags is None or self._tag_matches(item, tags):   
```

