### PR TITLE
Added support for python 2.6.6

### DIFF
--- a/influxdb/__init__.py
+++ b/influxdb/__init__.py
@@ -9,7 +9,6 @@ from .client import InfluxDBClient
 from .dataframe_client import DataFrameClient
 from .helper import SeriesHelper
 
-
 __all__ = [
     'InfluxDBClient',
     'DataFrameClient',

--- a/influxdb/line_protocol.py
+++ b/influxdb/line_protocol.py
@@ -23,19 +23,21 @@ def _convert_timestamp(timestamp, precision=None):
     if isinstance(timestamp, datetime):
         if not timestamp.tzinfo:
             timestamp = UTC.localize(timestamp)
-        ns = (timestamp - EPOCH).total_seconds() * 1e9
-        if precision is None or precision == 'n':
-            return ns
-        elif precision == 'u':
-            return ns / 1e3
-        elif precision == 'ms':
-            return ns / 1e6
-        elif precision == 's':
-            return ns / 1e9
-        elif precision == 'm':
-            return ns / 1e9 / 60
-        elif precision == 'h':
-            return ns / 1e9 / 3600
+            td = (timestamp - EPOCH)
+            ns = ((td.microseconds + (td.seconds + td.days * 24 * 3600) *
+                   10 ** 6) / 10 ** 6) * 1e9
+            if precision is None or precision == 'n':
+                return ns
+            elif precision == 'u':
+                return ns / 1e3
+            elif precision == 'ms':
+                return ns / 1e6
+            elif precision == 's':
+                return ns / 1e9
+            elif precision == 'm':
+                return ns / 1e9 / 60
+            elif precision == 'h':
+                return ns / 1e9 / 3600
     raise ValueError(timestamp)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+unittest2
 python-dateutil>=2.0.0
 pytz
 requests>=1.0.3


### PR DESCRIPTION
Added work around for AttributeError: 'datetime.timedelta' object has no attribute 'total_seconds' as suggested in  [https://docs.python.org/2/library/datetime.html#datetime.timedelta.total_seconds](url).

Even though Python 2.6.6 has been EOL for quite a while, there are still some systems that have it as their main Python interpreter like CentOS 6 and the only way to use a more recent version of Python is to install the SCL repo along with a few additional changes which a little bit more complicated or not feasible if the user doesn't have admin rights.