### PR TITLE
update python version in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,9 +43,9 @@ On Debian/Ubuntu, you can install it with this command::
 Dependencies
 ============
 
-The InfluxDB-Python distribution is supported and tested on Python 2.7, 3.3, 3.4, PyPy and PyPy3.
+The InfluxDB-Python distribution is supported and tested on Python 2.7, 3.3, 3.4, 3.5, 3.6, PyPy and PyPy3.
 
-**Note:** Python 3.2 is currently untested. See ``.travis.yml``. 
+**Note:** Python 3.2 is currently untested. See ``.travis.yml``.
 
 Main dependency is:
 


### PR DESCRIPTION
According to `.travis.yml` 3.5 and 3.6 are both supported.