### PR TITLE
_is_float should return false rather than an error when types are incompatible

### DIFF
--- a/influxdb/line_protocol.py
+++ b/influxdb/line_protocol.py
@@ -75,7 +75,7 @@ def quote_literal(value):
 def _is_float(value):
     try:
         float(value)
-    except ValueError:
+    except (TypeError, ValueError):
         return False
 
     return True


### PR DESCRIPTION
Currently a pandas Datetime column can cause an error to be thrown unnecessarily