### PR TITLE
fix issue with repr and Decimal

### DIFF
--- a/influxdb/line_protocol.py
+++ b/influxdb/line_protocol.py
@@ -90,6 +90,14 @@ def _escape_value(value):
         return str(value) + 'i'
     elif _is_float(value):
         return repr(value)
+        reprvalue = repr(value)
+        decimalstart = "Decimal('"
+        decimalstop = "')"
+        if reprvalue.startswith(decimalstart):
+            return reprvalue.lstrip(decimalstart).rstrip(decimalstop)
+        else:
+            return reprvalue
+
 
     return str(value)
 


### PR DESCRIPTION
Given the issue #431 fixing a precision issue while using python 2.x, as demonstrated by the example below:
```
$ python
Python 2.7.13 (default, Jan 19 2017, 14:48:08)
>>> float(repr(0.8289445733333332)) == 0.8289445733333332
True
>>> float(str(0.8289445733333332)) == 0.8289445733333332
False
>>>
```

We have now an issue as described in #430 and #482 with both Python and Python3 and the use of both Decimal Python type and repr, because :
```
>>> from decimal import Decimal
>>> str(Decimal(0.8289445733333332))
'0.828944573333333156739399782964028418064117431640625'
>>> repr(Decimal(0.8289445733333332))
"Decimal('0.828944573333333156739399782964028418064117431640625')"
```
In Python 3, str() and repr() now provides the same result with a float:
```
$ python3
Python 3.5.3+ (default, Jun  7 2017, 23:23:48) 
>>> float(repr(0.8289445733333332)) == 0.8289445733333332
True
>>> float(str(0.8289445733333332)) == 0.8289445733333332
True
>>>
```

But the problems remain while using both Decimal and repr(). The pull request offers a solution which should work both for python2 and python3.

Regards,
Carl