### PR TITLE
Fix for  influxdata/influxdb-python#479 : DataFrameClient issue - seems does not process correctly DateTimeIndex dates

### DIFF
--- a/influxdb/_dataframe_client.py
+++ b/influxdb/_dataframe_client.py
@@ -177,8 +177,8 @@ class DataFrameClient(InfluxDBClient):
         if not isinstance(dataframe, pd.DataFrame):
             raise TypeError('Must be DataFrame, but type was: {0}.'
                             .format(type(dataframe)))
-        if not (isinstance(dataframe.index, pd.tseries.period.PeriodIndex) or
-                isinstance(dataframe.index, pd.tseries.index.DatetimeIndex)):
+        if not (isinstance(dataframe.index, pd.PeriodIndex) or
+                isinstance(dataframe.index, pd.DatetimeIndex)):
             raise TypeError('Must be DataFrame with DatetimeIndex or \
                             PeriodIndex.')
 
@@ -234,8 +234,8 @@ class DataFrameClient(InfluxDBClient):
         if not isinstance(dataframe, pd.DataFrame):
             raise TypeError('Must be DataFrame, but type was: {0}.'
                             .format(type(dataframe)))
-        if not (isinstance(dataframe.index, pd.tseries.period.PeriodIndex) or
-                isinstance(dataframe.index, pd.tseries.index.DatetimeIndex)):
+        if not (isinstance(dataframe.index, pd.PeriodIndex) or
+                isinstance(dataframe.index, pd.DatetimeIndex)):
             raise TypeError('Must be DataFrame with DatetimeIndex or \
                             PeriodIndex.')
 
@@ -279,7 +279,7 @@ class DataFrameClient(InfluxDBClient):
         }.get(time_precision, 1)
 
         # Make array of timestamp ints
-        if isinstance(dataframe.index, pd.tseries.period.PeriodIndex):
+        if isinstance(dataframe.index, pd.PeriodIndex):
             time = ((dataframe.index.to_timestamp().values.astype(int) /
                      precision_factor).astype(int).astype(str))
         else:

--- a/influxdb/_dataframe_client.py
+++ b/influxdb/_dataframe_client.py
@@ -10,6 +10,7 @@ import math
 from collections import defaultdict
 
 import pandas as pd
+import numpy as np
 
 from .client import InfluxDBClient
 from .line_protocol import _escape_tag
@@ -326,10 +327,10 @@ class DataFrameClient(InfluxDBClient):
         # Make array of timestamp ints
         if isinstance(dataframe.index, pd.PeriodIndex):
             time = ((dataframe.index.to_timestamp().values.astype(int) /
-                     precision_factor).astype(int).astype(str))
+                     precision_factor).astype(np.int64).astype(str))
         else:
             time = ((pd.to_datetime(dataframe.index).values.astype(int) /
-                     precision_factor).astype(int).astype(str))
+                     precision_factor).astype(np.int64).astype(str))
 
         # If tag columns exist, make an array of formatted tag keys and values
         if tag_columns:

--- a/influxdb/_dataframe_client.py
+++ b/influxdb/_dataframe_client.py
@@ -258,7 +258,7 @@ class DataFrameClient(InfluxDBClient):
             {'measurement': measurement,
              'tags': dict(list(tag.items()) + list(tags.items())),
              'fields': rec,
-             'time': int(ts.value / precision_factor)}
+             'time': np.int64(ts.value / precision_factor)}
             for ts, tag, rec in zip(dataframe.index,
                                     dataframe[tag_columns].to_dict('record'),
                                     dataframe[field_columns].to_dict('record'))
@@ -326,10 +326,10 @@ class DataFrameClient(InfluxDBClient):
 
         # Make array of timestamp ints
         if isinstance(dataframe.index, pd.PeriodIndex):
-            time = ((dataframe.index.to_timestamp().values.astype(int) /
+            time = ((dataframe.index.to_timestamp().values.astype(np.int64) /
                      precision_factor).astype(np.int64).astype(str))
         else:
-            time = ((pd.to_datetime(dataframe.index).values.astype(int) /
+            time = ((pd.to_datetime(dataframe.index).values.astype(np.int64) /
                      precision_factor).astype(np.int64).astype(str))
 
         # If tag columns exist, make an array of formatted tag keys and values

--- a/influxdb/influxdb08/dataframe_client.py
+++ b/influxdb/influxdb08/dataframe_client.py
@@ -128,12 +128,12 @@ class DataFrameClient(InfluxDBClient):
         if not isinstance(dataframe, pd.DataFrame):
             raise TypeError('Must be DataFrame, but type was: {0}.'
                             .format(type(dataframe)))
-        if not (isinstance(dataframe.index, pd.tseries.period.PeriodIndex) or
-                isinstance(dataframe.index, pd.tseries.index.DatetimeIndex)):
+        if not (isinstance(dataframe.index, pd.PeriodIndex) or
+                isinstance(dataframe.index, pd.DatetimeIndex)):
             raise TypeError('Must be DataFrame with DatetimeIndex or \
                             PeriodIndex.')
 
-        if isinstance(dataframe.index, pd.tseries.period.PeriodIndex):
+        if isinstance(dataframe.index, pd.PeriodIndex):
             dataframe.index = dataframe.index.to_timestamp()
         else:
             dataframe.index = pd.to_datetime(dataframe.index)


### PR DESCRIPTION
Fix for  influxdata/influxdb-python#479
On windows machine, casting to int does not work properly to convert DateTimeIndex into Unix Epoch (required for Influx). Conversion to np.int64 solves the issue