### PR TITLE
Fixes typo in Content-Type header

### DIFF
--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -113,7 +113,7 @@ class InfluxDBClient(object):
             self._port)
 
         self._headers = {
-            'Content-type': 'application/json',
+            'Content-Type': 'application/json',
             'Accept': 'text/plain'
         }
 
@@ -283,7 +283,7 @@ class InfluxDBClient(object):
         :rtype: bool
         """
         headers = self._headers
-        headers['Content-type'] = 'application/octet-stream'
+        headers['Content-Type'] = 'application/octet-stream'
 
         if params:
             precision = params.get('precision')


### PR DESCRIPTION
This PR fixes the name of the `Content-Type` header.

Even though requests uses a case-insensitive dict for storing HTTP headers, I think it's better form to use [proper naming](https://www.w3.org/Protocols/rfc1341/4_Content-Type.html). 