### PR TITLE
Make the pandas client easy to use, and fix the precision invalids

### DIFF
--- a/influxdb/_dataframe_client.py
+++ b/influxdb/_dataframe_client.py
@@ -233,8 +233,10 @@ class DataFrameClient(InfluxDBClient):
         tags = tags if tags is not None else {}
         # Assume field columns are all columns not included in tag columns
         if not field_columns:
-            field_columns = list(
-                set(dataframe.columns).difference(set(tag_columns)))
+            #field_columns = list(
+            #    set(dataframe.columns).difference(set(tag_columns)))
+            field_columns_buf = list(set(dataframe.columns).difference(set(tag_columns)))
+            field_columns = [str(field_column) for field_column in field_columns_buf]
 
         dataframe.index = dataframe.index.to_datetime()
         if dataframe.index.tzinfo is None:

--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -492,7 +492,7 @@ class InfluxDBClient(object):
                       retention_policy,
                       tags,
                       protocol='json'):
-        if time_precision not in ['n', 'u', 'ms', 's', 'm', 'h', None]:
+        if time_precision not in ['n', 'u', 'ms', 's', 'm', 'h', 'N', 'U', 'L', 'S', 'M', 'H', None]:
             raise ValueError(
                 "Invalid time precision is given. "
                 "(use 'n', 'u', 'ms', 's', 'm' or 'h')")


### PR DESCRIPTION
Here, I just make the pandas dataframe client convert the key to string automatically.
Further more, I found the example have a problem about time\_precision.
The time\_precision of dataframe client required the lower word, but pandas automatically make the freq in upper word.
I am not pretty sure did that's relative with the update of pandas, but I fixed it with consider about upper word and lower word at the same time.