### PR TITLE
Allow connecting to influxdb running on a path on the server

### DIFF
--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -59,6 +59,8 @@ class InfluxDBClient(object):
     :type udp_port: int
     :param proxies: HTTP(S) proxy to use for Requests, defaults to {}
     :type proxies: dict
+    :param path: path of InfluxDB on the server to connect, defaults to ''
+    :type path: str
     """
 
     def __init__(self,
@@ -75,10 +77,12 @@ class InfluxDBClient(object):
                  udp_port=4444,
                  proxies=None,
                  pool_size=10,
+                 path='',
                  ):
         """Construct a new InfluxDBClient object."""
         self.__host = host
         self.__port = int(port)
+        self.__path = path if not path or path[0] == '/' else '/' + path
         self._username = username
         self._password = password
         self._database = database
@@ -110,10 +114,11 @@ class InfluxDBClient(object):
         else:
             self._proxies = proxies
 
-        self.__baseurl = "{0}://{1}:{2}".format(
+        self.__baseurl = "{0}://{1}:{2}{3}".format(
             self._scheme,
             self._host,
-            self._port)
+            self._port,
+            self._path)
 
         self._headers = {
             'Content-Type': 'application/json',
@@ -131,6 +136,10 @@ class InfluxDBClient(object):
     @property
     def _port(self):
         return self.__port
+
+    @property
+    def _path(self):
+        return self.__path
 
     @property
     def _udp_port(self):

--- a/influxdb/tests/client_test.py
+++ b/influxdb/tests/client_test.py
@@ -109,6 +109,18 @@ class TestInfluxDBClient(unittest.TestCase):
         )
         self.assertEqual('https://host:8086', cli._baseurl)
 
+        cli = InfluxDBClient(
+            'host', 8086, 'username', 'password', 'database', ssl=True,
+            path="somepath"
+        )
+        self.assertEqual('https://host:8086/somepath', cli._baseurl)
+
+        cli = InfluxDBClient(
+            'host', 8086, 'username', 'password', 'database', ssl=True,
+            path="/somepath"
+        )
+        self.assertEqual('https://host:8086/somepath', cli._baseurl)
+
     def test_dsn(self):
         """Set up the test datasource name for TestInfluxDBClient object."""
         cli = InfluxDBClient.from_dsn('influxdb://192.168.0.1:1886')


### PR DESCRIPTION
Make it possible to connect to the databases on a path on servers.
https://someserver.com/myinfluxdb instead of the root of the server.