### PR TITLE
Add keyword to set the certificate files for ssl client authentication

### DIFF
--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -45,8 +45,8 @@ class InfluxDBClient(object):
         False
     :type ssl: bool
     :param verify_ssl: verify SSL certificates for HTTPS requests, defaults to
-        False
-    :type verify_ssl: bool
+        False. If a string it must specify the path of a CA bundle to use.
+    :type verify_ssl: bool or str
     :param timeout: number of seconds Requests will wait for your client to
         establish a connection, defaults to None
     :type timeout: int
@@ -59,6 +59,9 @@ class InfluxDBClient(object):
     :type udp_port: int
     :param proxies: HTTP(S) proxy to use for Requests, defaults to {}
     :type proxies: dict
+    :param ssl_cert: if string, path to ssl client cert file (.pem). If tuple,
+        ('cert', 'key') pair.
+    :type ssl_cert: str or tuple of str
     """
 
     def __init__(self,

--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -75,6 +75,7 @@ class InfluxDBClient(object):
                  udp_port=4444,
                  proxies=None,
                  pool_size=10,
+                 ssl_cert=None
                  ):
         """Construct a new InfluxDBClient object."""
         self.__host = host
@@ -86,6 +87,7 @@ class InfluxDBClient(object):
         self._retries = retries
 
         self._verify_ssl = verify_ssl
+        self._ssl_cert = ssl_cert
 
         self.__use_udp = use_udp
         self.__udp_port = udp_port
@@ -249,7 +251,8 @@ class InfluxDBClient(object):
                     headers=headers,
                     proxies=self._proxies,
                     verify=self._verify_ssl,
-                    timeout=self._timeout
+                    timeout=self._timeout,
+                    cert=self._ssl_cert
                 )
                 break
             except (requests.exceptions.ConnectionError,


### PR DESCRIPTION
This simple patch allow the client to pass a certificate to the server for ssl client authentication.

We use SSL client authentication extensively for many services and it would be great if the python influx client would support it out of the box.