### PR TITLE
specify the numpy dependency explicitly to prevent regression in test suite

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ setenv = INFLUXDB_PYTHON_SKIP_SERVER_TESTS=False
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
        py27,py34,py35,py36: pandas==0.20.1
+       py27,py34,py35,py36: numpy==1.13.3
 # Only install pandas with non-pypy interpreters
 commands = nosetests -v --with-doctest {posargs}
 
@@ -25,11 +26,13 @@ deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
        pandas
        coverage
+       numpy==1.13.3
 commands = nosetests -v --with-coverage --cover-html --cover-package=influxdb
 
 [testenv:docs]
 deps = -r{toxinidir}/requirements.txt
        pandas==0.20.1
+       numpy==1.13.3
        Sphinx==1.5.5
        sphinx_rtd_theme
 commands = sphinx-build -b html docs/source docs/build


### PR DESCRIPTION
numpy 1.14.0 introduces regressions to the unittests
https://docs.scipy.org/doc/numpy/release.html