### PR TITLE
Remove comment as issues have been resolved

### DIFF
--- a/examples/tutorial_pandas.py
+++ b/examples/tutorial_pandas.py
@@ -12,7 +12,6 @@ def main(host='localhost', port=8086):
     user = 'root'
     password = 'root'
     dbname = 'demo'
-    # Temporarily avoid line protocol time conversion issues #412, #426, #431.
     protocol = 'json'
 
     client = DataFrameClient(host, port, user, password, dbname)


### PR DESCRIPTION
It seems the instruction to avoid using the line protocol was created when there were issues that made the line protocol to fail. The issues have been since fixed and the line protocol works fine.