### PR TITLE
Update _dataframe_client.py

### DIFF
--- a/influxdb/_dataframe_client.py
+++ b/influxdb/_dataframe_client.py
@@ -236,7 +236,7 @@ class DataFrameClient(InfluxDBClient):
             field_columns = list(
                 set(dataframe.columns).difference(set(tag_columns)))
 
-        dataframe.index = dataframe.index.to_datetime()
+        dataframe.index = pd.to_datetime(dataframe.index)
         if dataframe.index.tzinfo is None:
             dataframe.index = dataframe.index.tz_localize('UTC')
 


### PR DESCRIPTION
Permanent error "NameError: name 'to_datetime' is not defined".
Reason: to_datetime is a function defined in pandas not a method on a DataFrame. (see: https://stackoverflow.com/questions/48387878/attributeerror-dataframe-object-has-no-attribute-to-datetime)
Tested with Python 3.5.3 and Pandas 0.23.0