### PR TITLE
Pass through method kwarg to DataFrameClient query method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 ### Changed
+- Pass through the "method" kwarg to DataFrameClient queries
 
 ### Removed
 

--- a/influxdb/_dataframe_client.py
+++ b/influxdb/_dataframe_client.py
@@ -148,9 +148,10 @@ class DataFrameClient(InfluxDBClient):
               raise_errors=True,
               chunked=False,
               chunk_size=0,
+              method="GET",
               dropna=True):
         """
-        Quering data into a DataFrame.
+        Query data into a DataFrame.
 
         :param query: the actual query string
         :param params: additional parameters for the request, defaults to {}
@@ -176,6 +177,7 @@ class DataFrameClient(InfluxDBClient):
                           raise_errors=raise_errors,
                           chunked=chunked,
                           database=database,
+                          method=method,
                           chunk_size=chunk_size)
         results = super(DataFrameClient, self).query(query, **query_args)
         if query.strip().upper().startswith("SELECT"):


### PR DESCRIPTION
Also, add db maintenance tests from InfluxDBClient

fixes #616