### PR TITLE
 if dataframe index is already DatatimeIndex, need not transform

### DIFF
--- a/influxdb/_dataframe_client.py
+++ b/influxdb/_dataframe_client.py
@@ -238,7 +238,8 @@ class DataFrameClient(InfluxDBClient):
             field_columns = list(
                 set(dataframe.columns).difference(set(tag_columns)))
 
-        dataframe.index = pd.to_datetime(dataframe.index)
+        if not isinstance(dataframe.index, pd.DatetimeIndex):
+            dataframe.index = pd.to_datetime(dataframe.index)
         if dataframe.index.tzinfo is None:
             dataframe.index = dataframe.index.tz_localize('UTC')
 


### PR DESCRIPTION
fix bug in _convert_dataframe_to_json function that need not transform index if data type of index is already DatatimeIndex