### PR TITLE
Parameter binding for client's `query()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+- query() now accepts a bind_params argument for parameter binding (#678 thx @clslgrnc)
 
 ### Changed
 

--- a/examples/tutorial.py
+++ b/examples/tutorial.py
@@ -13,7 +13,9 @@ def main(host='localhost', port=8086):
     dbname = 'example'
     dbuser = 'smly'
     dbuser_password = 'my_secret_password'
-    query = 'select value from cpu_load_short;'
+    query = 'select Float_value from cpu_load_short;'
+    query_where = 'select Int_value from cpu_load_short where host=$host;'
+    bind_params = {'host': 'server01'}
     json_body = [
         {
             "measurement": "cpu_load_short",
@@ -47,6 +49,11 @@ def main(host='localhost', port=8086):
 
     print("Querying data: " + query)
     result = client.query(query)
+
+    print("Result: {0}".format(result))
+
+    print("Querying data: " + query_where)
+    result = client.query(query_where, bind_params=bind_params)
 
     print("Result: {0}".format(result))
 

--- a/influxdb/_dataframe_client.py
+++ b/influxdb/_dataframe_client.py
@@ -142,6 +142,7 @@ class DataFrameClient(InfluxDBClient):
     def query(self,
               query,
               params=None,
+              bind_params=None,
               epoch=None,
               expected_response_code=200,
               database=None,
@@ -153,8 +154,18 @@ class DataFrameClient(InfluxDBClient):
         """
         Query data into a DataFrame.
 
+        .. danger::
+            In order to avoid injection vulnerabilities (similar to `SQL
+            injection <https://www.owasp.org/index.php/SQL_Injection>`_
+            vulnerabilities), do not directly include untrusted data into the
+            ``query`` parameter, use ``bind_params`` instead.
+
         :param query: the actual query string
         :param params: additional parameters for the request, defaults to {}
+        :param bind_params: bind parameters for the query:
+            any variable in the query written as ``'$var_name'`` will be
+            replaced with ``bind_params['var_name']``. Only works in the
+            ``WHERE`` clause and takes precedence over ``params['params']``
         :param epoch: response timestamps to be in epoch format either 'h',
             'm', 's', 'ms', 'u', or 'ns',defaults to `None` which is
             RFC3339 UTC format with nanosecond precision
@@ -172,6 +183,7 @@ class DataFrameClient(InfluxDBClient):
         :rtype: :class:`~.ResultSet`
         """
         query_args = dict(params=params,
+                          bind_params=bind_params,
                           epoch=epoch,
                           expected_response_code=expected_response_code,
                           raise_errors=raise_errors,

--- a/influxdb/tests/dataframe_client_test.py
+++ b/influxdb/tests/dataframe_client_test.py
@@ -884,10 +884,11 @@ class TestDataFrameClient(unittest.TestCase):
         expected = [{'cpu_load_short': pd1}, {'cpu_load_short': pd2}]
 
         cli = DataFrameClient('host', 8086, 'username', 'password', 'db')
-        iql = "SELECT value FROM cpu_load_short WHERE region='us-west';"\
-            "SELECT count(value) FROM cpu_load_short WHERE region='us-west'"
+        iql = "SELECT value FROM cpu_load_short WHERE region=$region;"\
+            "SELECT count(value) FROM cpu_load_short WHERE region=$region"
+        bind_params = {'region': 'us-west'}
         with _mocked_session(cli, 'GET', 200, data):
-            result = cli.query(iql)
+            result = cli.query(iql, bind_params=bind_params)
             for r, e in zip(result, expected):
                 for k in e:
                     assert_frame_equal(e[k], r[k])

--- a/influxdb/tests/server_tests/client_test_with_server.py
+++ b/influxdb/tests/server_tests/client_test_with_server.py
@@ -440,7 +440,9 @@ class CommonTests(ManyTestCasesWithServerMixin, unittest.TestCase):
                               batch_size=2)
         time.sleep(5)
         net_in = self.cli.query("SELECT value FROM network "
-                                "WHERE direction='in'").raw
+                                "WHERE direction=$dir",
+                                bind_params={'dir': 'in'}
+                                ).raw
         net_out = self.cli.query("SELECT value FROM network "
                                  "WHERE direction='out'").raw
         cpu = self.cli.query("SELECT value FROM cpu_usage").raw


### PR DESCRIPTION
Closes #603, closes #316. Enables the following:
```python
client.query('select Int_value from cpu_load_short where host=$host_var;',
             bind_params={'host_var': 'server01'})
```

~~The last commit ensures all tests pass and is unrelated to the rest of this PR (feel free to revert it, #671 is probably a better suggestion).~~