### PR TITLE
Fix Travis and Panda tz_localize

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "2.7"
   - "3.5"
   - "3.6"
-  - "pypy-5.3.1"
+  - "pypy"
   - "pypy3"
 
 env:
@@ -12,6 +12,7 @@ env:
   - INFLUXDB_VER=1.3.9
   - INFLUXDB_VER=1.4.2
   - INFLUXDB_VER=1.5.4
+  - INFLUXDB_VER=1.7.2
 
 addons:
   apt:

--- a/influxdb/_dataframe_client.py
+++ b/influxdb/_dataframe_client.py
@@ -202,7 +202,8 @@ class DataFrameClient(InfluxDBClient):
             df = pd.DataFrame(data)
             df.time = pd.to_datetime(df.time)
             df.set_index('time', inplace=True)
-            df.index = df.index.tz_localize('UTC')
+            if df.index.tzinfo is None:
+                df.index = df.index.tz_localize('UTC')
             df.index.name = None
             result[key].append(df)
         for key, data in result.items():

--- a/influxdb/tests/dataframe_client_test.py
+++ b/influxdb/tests/dataframe_client_test.py
@@ -818,13 +818,15 @@ class TestDataFrameClient(unittest.TestCase):
         pd1 = pd.DataFrame(
             [[23422]], columns=['value'],
             index=pd.to_datetime(["2009-11-10T23:00:00Z"]))
-        pd1.index = pd1.index.tz_localize('UTC')
+        if pd1.index.tzinfo is None:
+            pd1.index = pd1.index.tz_localize('UTC')
         pd2 = pd.DataFrame(
             [[23422], [23422], [23422]], columns=['value'],
             index=pd.to_datetime(["2009-11-10T23:00:00Z",
                                   "2009-11-10T23:00:00Z",
                                   "2009-11-10T23:00:00Z"]))
-        pd2.index = pd2.index.tz_localize('UTC')
+        if pd2.index.tzinfo is None:
+            pd2.index = pd2.index.tz_localize('UTC')
         expected = {
             ('network', (('direction', ''),)): pd1,
             ('network', (('direction', 'in'),)): pd2
@@ -871,11 +873,14 @@ class TestDataFrameClient(unittest.TestCase):
             index=pd.to_datetime([
                 "2015-01-29 21:55:43.702900257+0000",
                 "2015-01-29 21:55:43.702900257+0000",
-                "2015-06-11 20:46:02+0000"])).tz_localize('UTC')
+                "2015-06-11 20:46:02+0000"]))
+        if pd1.index.tzinfo is None:
+            pd1.index = pd1.index.tz_localize('UTC')
         pd2 = pd.DataFrame(
             [[3]], columns=['count'],
-            index=pd.to_datetime(["1970-01-01 00:00:00+00:00"]))\
-            .tz_localize('UTC')
+            index=pd.to_datetime(["1970-01-01 00:00:00+00:00"]))
+        if pd2.index.tzinfo is None:
+            pd2.index = pd2.index.tz_localize('UTC')
         expected = [{'cpu_load_short': pd1}, {'cpu_load_short': pd2}]
 
         cli = DataFrameClient('host', 8086, 'username', 'password', 'db')

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ commands = nosetests -v --with-doctest {posargs}
 deps =
   flake8
   pep8-naming
-commands = flake8 --ignore=W503,W504,W605,N802,F821 influxdb
+commands = flake8 --ignore=W503,W504,W605,N802,N816,F821 influxdb
 
 [testenv:pep257]
 deps = pydocstyle


### PR DESCRIPTION
Travis is still broken.

It should work with the included changes:
- unpin pypy as cryptography-2.5 is not compatible with PyPy < 5.4 (see [failed build](https://travis-ci.org/influxdata/influxdb-python/jobs/492607023))
- apply @f4bsch patch (see [failed build](https://travis-ci.org/influxdata/influxdb-python/jobs/486383231), closes #671 and closes #676)
- ignore N816 `mixedCase variable in global scope`, might not be the best solution but getting travis back up should be a priority (see [failed build](https://travis-ci.org/influxdata/influxdb-python/jobs/492607042)).