### PR TITLE
ignore N816: mixedCase variable in global scope

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ commands = nosetests -v --with-doctest {posargs}
 deps =
   flake8
   pep8-naming
-commands = flake8 --ignore=W503,W504,W605,N802,F821 influxdb
+commands = flake8 --ignore=W503,W504,W605,N802,N816,F821 influxdb
 
 [testenv:pep257]
 deps = pydocstyle


### PR DESCRIPTION
ignore N816 `mixedCase variable in global scope`, might not be the best solution but getting travis back up should be a priority (see [failed build](https://travis-ci.org/influxdata/influxdb-python/jobs/492607042)).

Extracted from #679 