### PR TITLE
Line protocol leading comma

### DIFF
--- a/influxdb/_dataframe_client.py
+++ b/influxdb/_dataframe_client.py
@@ -385,7 +385,7 @@ class DataFrameClient(InfluxDBClient):
         # Generate line protocol string
         measurement = _escape_tag(measurement)
         # prepend comma to non-Null tag-rows
-        tags = pd.Series("," + tags).str.replace(r"^,$","")
+        tags = ("," + tags).str.replace(r"^,$","")
         points = (measurement + tags + ' ' + fields + ' ' + time).tolist()
         return points
 

--- a/influxdb/_dataframe_client.py
+++ b/influxdb/_dataframe_client.py
@@ -363,7 +363,7 @@ class DataFrameClient(InfluxDBClient):
             tag_df = self._stringify_dataframe(
                 tag_df, numeric_precision, datatype='tag')
 
-            # join preprendded tags, leaving None values out
+            # join prepended tags, leaving None values out
             tags = tag_df.apply(
                 lambda s: [',' + s.name + '=' + v if v else '' for v in s])
             tags = tags.sum(axis=1)
@@ -392,6 +392,8 @@ class DataFrameClient(InfluxDBClient):
             field_df.columns[1:]]
         field_df = field_df.where(~mask_null, '')  # drop Null entries
         fields = field_df.sum(axis=1)
+        # take out leading , where first column has a Null value
+        fields = fields.str.lstrip(",")
         del field_df
 
         # Generate line protocol string

--- a/influxdb/_dataframe_client.py
+++ b/influxdb/_dataframe_client.py
@@ -385,7 +385,7 @@ class DataFrameClient(InfluxDBClient):
         # Generate line protocol string
         measurement = _escape_tag(measurement)
         # prepend comma to non-Null tag-rows
-        tags = ("," + tags).str.replace(r"^,$","")
+        tags = pd.Series("," + tags).str.replace(r"^,$","")
         points = (measurement + tags + ' ' + fields + ' ' + time).tolist()
         return points
 

--- a/influxdb/_dataframe_client.py
+++ b/influxdb/_dataframe_client.py
@@ -358,11 +358,17 @@ class DataFrameClient(InfluxDBClient):
                     tag_columns.append(tag)
 
             tag_df = dataframe[tag_columns]
-            # Keep the positions where Null values are found
-            mask_null = tag_df.isnull().values
-            tag_df = self._stringify_dataframe(tag_df, numeric_precision, datatype='tag')
-            tags = self._lineify_string_df(tag_df,mask_null)
-            del tag_df, mask_null
+            tag_df = tag_df.fillna('')  # replace NA with empty string
+            tag_df = tag_df.sort_index(axis=1)
+            tag_df = self._stringify_dataframe(
+                tag_df, numeric_precision, datatype='tag')
+
+            # join prepended tags, leaving None values out
+            tags = tag_df.apply(
+                lambda s: [',' + s.name + '=' + v if v else '' for v in s])
+            tags = tags.sum(axis=1)
+
+            del tag_df
         elif global_tags:
             tag_string = ''.join(
                 [",{}={}".format(k, _escape_tag(v)) if v else ''
@@ -376,16 +382,22 @@ class DataFrameClient(InfluxDBClient):
         field_df = dataframe[field_columns]
         # Keep the positions where Null values are found
         mask_null = field_df.isnull().values
+
         field_df = self._stringify_dataframe(field_df,
-                                              numeric_precision,
-                                              datatype='field')
-        fields = self._lineify_string_df(field_df, mask_null)
-        del field_df, mask_null
+                                             numeric_precision,
+                                             datatype='field')
+
+        field_df = (field_df.columns.values + '=').tolist() + field_df
+        field_df[field_df.columns[1:]] = ',' + field_df[
+            field_df.columns[1:]]
+        field_df = field_df.where(~mask_null, '')  # drop Null entries
+        fields = field_df.sum(axis=1)
+        # take out leading , where first column has a Null value
+        fields = fields.str.lstrip(",")
+        del field_df
 
         # Generate line protocol string
         measurement = _escape_tag(measurement)
-        # prepend comma to non-Null tag-rows
-        tags = ("," + tags).str.replace(r"^,$","")
         points = (measurement + tags + ' ' + fields + ' ' + time).tolist()
         return points
 
@@ -440,22 +452,6 @@ class DataFrameClient(InfluxDBClient):
         dframe.columns = dframe.columns.astype(str)
 
         return dframe
-
-
-    def _lineify_string_df(self,string_df,mask_null):
-        """accepts a dataframe of tag or field df
-           returns a Series of strings joined by
-                comma if non-Null values using
-                vector string operations"""
-        df = string_df.copy()
-        df = (df.columns.values + '=').tolist() + df
-        df[df.columns[1:]] = ',' + df[df.columns[1:]]
-        df = df.where(~mask_null, '')  # drop Null entries
-        lineified_string_series = df.sum(axis=1)
-        # take out leading comma where first column has a Null value
-        lineified_string_series = lineified_string_series.str.lstrip(",")
-        return lineified_string_series
-
 
     def _datetime_to_epoch(self, datetime, time_precision='s'):
         seconds = (datetime - self.EPOCH).total_seconds()

--- a/influxdb/tests/dataframe_client_test.py
+++ b/influxdb/tests/dataframe_client_test.py
@@ -390,8 +390,7 @@ class TestDataFrameClient(unittest.TestCase):
             self.assertEqual(m.last_request.body, expected)
 
     def test_write_points_from_dataframe_with_leading_none_column(self):
-        """Test write points from df in TestDataFrameClient object 
-        to check if leading None column results in invalid line protocol."""
+        """write_points detect erroneous leading comma for null first field."""
         dataframe = pd.DataFrame(
             dict(
                 first=[1, None, None, 8, 9],
@@ -415,11 +414,20 @@ class TestDataFrameClient(unittest.TestCase):
             )
         )
         expected = (
-            b'foo,first_tag=one,second_tag=two,third_tag=three comment="All columns filled",first=1.0,second=2.0,third=3.0 1514764800000000000\n'
-            b'foo,third_tag=four comment="First two of three empty",third=4.1 1514851200000000000\n'
+            b'foo,first_tag=one,second_tag=two,third_tag=three'
+            b' comment="All columns filled",first=1.0,second=2.0,third=3.0'
+            b' 1514764800000000000\n'
+            b'foo,third_tag=four'
+            b' comment="First two of three empty",third=4.1'
+            b' 1514851200000000000\n'
             b'foo comment="All empty" 1514937600000000000\n'
-            b'foo,first_tag=eight comment="Last two of three empty",first=8.0 1515024000000000000\n'
-            b'foo comment="Empty tags with values",first=9.0,second=10.0,third=11.0 1515110400000000000\n'
+            b'foo,first_tag=eight'
+            b' comment="Last two of three empty",first=8.0'
+            b' 1515024000000000000\n'
+            b'foo'
+            b' comment="Empty tags with values",first=9.0,second=10.0'
+            b',third=11.0'
+            b' 1515110400000000000\n'
         )
 
         with requests_mock.Mocker() as m:
@@ -443,7 +451,7 @@ class TestDataFrameClient(unittest.TestCase):
                                  "first_tag",
                                  "second_tag",
                                  "third_tag"])
-            
+
             self.assertEqual(m.last_request.body, expected)
 
     def test_write_points_from_dataframe_with_numeric_precision(self):

--- a/influxdb/tests/dataframe_client_test.py
+++ b/influxdb/tests/dataframe_client_test.py
@@ -410,7 +410,7 @@ class TestDataFrameClient(unittest.TestCase):
             ),
             index=pd.date_range(
                 start=pd.to_datetime('2018-01-01'),
-                end=pd.to_datetime('2018-10-01'),
+                freq='1D',
                 periods=5,
             )
         )

--- a/influxdb/tests/dataframe_client_test.py
+++ b/influxdb/tests/dataframe_client_test.py
@@ -434,9 +434,7 @@ class TestDataFrameClient(unittest.TestCase):
                                  "first_tag",
                                  "second_tag",
                                  "third_tag"])
-            with open('/tmp/mylog.txt', 'w') as of:
-                print(m.last_request.body, expected, file=of)
-
+            
             self.assertEqual(m.last_request.body, expected)
 
     def test_write_points_from_dataframe_with_numeric_precision(self):

--- a/influxdb/tests/dataframe_client_test.py
+++ b/influxdb/tests/dataframe_client_test.py
@@ -438,7 +438,7 @@ class TestDataFrameClient(unittest.TestCase):
                 "second",
                 "third"
             ]
-            cli.write_points(dataframe[colnames], 'foo',
+            cli.write_points(dataframe.loc[:, colnames], 'foo',
                              tag_columns=[
                                  "first_tag",
                                  "second_tag",

--- a/influxdb/tests/dataframe_client_test.py
+++ b/influxdb/tests/dataframe_client_test.py
@@ -429,7 +429,16 @@ class TestDataFrameClient(unittest.TestCase):
 
             cli = DataFrameClient(database='db')
 
-            cli.write_points(dataframe, 'foo',
+            colnames = [
+                "first_tag",
+                "second_tag",
+                "third_tag",
+                "comment",
+                "first",
+                "second",
+                "third"
+            ]
+            cli.write_points(dataframe[colnames], 'foo',
                              tag_columns=[
                                  "first_tag",
                                  "second_tag",

--- a/influxdb/tests/dataframe_client_test.py
+++ b/influxdb/tests/dataframe_client_test.py
@@ -415,11 +415,11 @@ class TestDataFrameClient(unittest.TestCase):
             )
         )
         expected = (
-            b'foo,first_tag=one,second_tag=two,third_tag=three first=1.0,second=2.0,third=3.0,comment="All columns filled" 1514764800000000000\n'
-            b'foo,third_tag=four third=4.1,comment="First two of three empty" 1514851200000000000\n'
+            b'foo,first_tag=one,second_tag=two,third_tag=three comment="All columns filled",first=1.0,second=2.0,third=3.0 1514764800000000000\n'
+            b'foo,third_tag=four comment="First two of three empty",third=4.1 1514851200000000000\n'
             b'foo comment="All empty" 1514937600000000000\n'
-            b'foo,first_tag=eight first=8.0,comment="Last two of three empty"  1515024000000000000\n'
-            b'foo first=9.0,second=10.0,third=11.0,comment="Empty tags with values" 1515110400000000000\n'
+            b'foo,first_tag=eight comment="Last two of three empty",first=8.0 1515024000000000000\n'
+            b'foo comment="Empty tags with values",first=9.0,second=10.0,third=11.0 1515110400000000000\n'
         )
 
         with requests_mock.Mocker() as m:

--- a/influxdb/tests/dataframe_client_test.py
+++ b/influxdb/tests/dataframe_client_test.py
@@ -410,17 +410,16 @@ class TestDataFrameClient(unittest.TestCase):
             ),
             index=pd.date_range(
                 start=pd.to_datetime('2018-01-01'),
-                end=pd.to_datetime('2018-10-01'),
-                freq=None,
+                freq='1D',
                 periods=5,
             )
         )
         expected = (
             b'foo,first_tag=one,second_tag=two,third_tag=three first=1.0,second=2.0,third=3.0,comment="All columns filled" 1514764800000000000\n'
-            b'foo,third_tag=four third=4.1,comment="First two of three empty" 1520661600000000000\n'
-            b'foo comment="All empty" 1526558400000000000\n'
-            b'foo,first_tag=eight first=8.0,comment="Last two of three empty" 1532455200000000000\n'
-            b'foo first=9.0,second=10.0,third=11.0,comment="Empty tags with values" 1538352000000000000\n'
+            b'foo,third_tag=four third=4.1,comment="First two of three empty" 1514851200000000000\n'
+            b'foo comment="All empty" 1514937600000000000\n'
+            b'foo,first_tag=eight first=8.0,comment="Last two of three empty"  1515024000000000000\n'
+            b'foo first=9.0,second=10.0,third=11.0,comment="Empty tags with values" 1515110400000000000\n'
         )
 
         with requests_mock.Mocker() as m:


### PR DESCRIPTION
**Environment:**
- `pandas==0.24.1`
- `-e git+ssh://git@github.com/KuguHome/influxdb-python.git@afcfd25b21523d84a7d1088eff2abb4d08de7647#egg=influxdb` which mirrors the current master branch of influxdb-python
- `python=3.6.7`

**Reproduction of bug:**
`bug-reproduce.py`
```py
import pandas as pd
from influxdb import DataFrameClient

dfi = DataFrameClient(database='testdb', )
dfi.create_database('testdb')

# create a test dataframe that reproduces the bug
buggy_df = pd.DataFrame(
	dict(
		first=[1, None, None, 8, 9],
		second=[2, None, None, None, 10],
                third=[3, 4.1, None, None, 11],
		first_tag=["one", None, None, "eight", None],
		second_tag=["two", None, None, None, None],
                third_tag=["three", "four", None, None, None],
                comment=[
                    "All columns filled",
                    "First two of three empty",
                    "All empty",
                    "Last two of three empty",
                    "Empty tags with values",
                ]
	),
	index=pd.date_range(
		start=pd.to_datetime('2018-01-01'),
		end=pd.to_datetime('2018-10-01'),
		periods=5,
	)
)
print("bug inducing df=\n",buggy_df)
print("\nbuggy line protocol output\n",
      "\n" + "\n".join(
		dfi._convert_dataframe_to_lines(
			buggy_df.iloc[:,:-1],
			'buggy-measurements',
			tag_columns=["first_tag", "second_tag","third_tag"],
		)
	)
)
```

```sh
$ python bug-reproduce.py
bug inducing df=
                      first  second  third first_tag second_tag third_tag                   comment
2018-01-01 00:00:00    1.0     2.0    3.0       one        two     three        All columns filled
2018-03-10 06:00:00    NaN     NaN    4.1      None       None      four  First two of three empty
2018-05-17 12:00:00    NaN     NaN    NaN      None       None      None                 All empty
2018-07-24 18:00:00    8.0     NaN    NaN     eight       None      None   Last two of three empty
2018-10-01 00:00:00    9.0    10.0   11.0      None       None      None    Empty tags with values

buggy line protocol output
 
buggy-measurements,first_tag=one,second_tag=two,third_tag=three first=1.0,second=2.0,third=3.0 1514764800000000000
buggy-measurements,third_tag=four ,third=4.1 1520661600000000000
buggy-measurements,first_tag=eight first=8.0 1532455200000000000
buggy-measurements first=9.0,second=10.0,third=11.0 1538352000000000000
```
**Outlook:**
Although tags and fields are handled the same way, the presence of a leading comma works for the tags. The following code is where the values are handled : 

https://github.com/influxdata/influxdb-python/blob/afcfd25b21523d84a7d1088eff2abb4d08de7647/influxdb/_dataframe_client.py#L381-L394

Notice the difference to how tags are handled, in that the None columns are filtered out by value before conversion to line protocol. The values, however, are handled by the column index i.e `field_df[field_df.columns[1:]] = ',' + field_df[
            field_df.columns[1:]] `

https://github.com/influxdata/influxdb-python/blob/afcfd25b21523d84a7d1088eff2abb4d08de7647/influxdb/_dataframe_client.py#L366-L369

**Fix and refactor:**
1. **[FIX]** I would have proposed that the fields are handled exactly the same way as the tags. However, the tag operation uses apply (which is slower), whereas the field operation uses vectorized operation. So the performant fix here would be to strip the leading `,` from `fields` where appropriate.
  https://github.com/KuguHome/influxdb-python/commit/b4ceab9b7d201b270b9a46fdedba2133a85c1f99
   **Output:**
   ```sh
   python bug-reproduce.py
   bug inducing df=
                         first  second  third first_tag second_tag third_tag                   comment
   2018-01-01 00:00:00    1.0     2.0    3.0       one        two     three        All columns filled
   2018-03-10 06:00:00    NaN     NaN    4.1      None       None      four  First two of three empty
   2018-05-17 12:00:00    NaN     NaN    NaN      None       None      None                 All empty
   2018-07-24 18:00:00    8.0     NaN    NaN     eight       None      None   Last two of three empty
   2018-10-01 00:00:00    9.0    10.0   11.0      None       None      None    Empty tags with values
   
   buggy line protocol output
    
   buggy-measurements,first_tag=one,second_tag=two,third_tag=three first=1.0,second=2.0,third=3.0 1514764800000000000
   buggy-measurements,third_tag=four third=4.1 1520661600000000000
   buggy-measurements,first_tag=eight first=8.0 1532455200000000000
   buggy-measurements first=9.0,second=10.0,third=11.0 1538352000000000000
   ```
2. **[REFACTOR]** Since the logic for handling tags and values are exactly the same, these two chunks should be refactored into a utility function called `__lineify_tag_field_df`, because DRY. 
    The leading `,` needs to be taken out from the `tags` output and needs to be put back when constructing the line again.
    https://github.com/KuguHome/influxdb-python/commit/366e7714668cc1fd28b5a5f689e93661f1b9da5f
   **Output:**
   ```sh
   python bug-reproduce.py           
   bug inducing df=
                         first  second  third first_tag second_tag third_tag                   comment
   2018-01-01 00:00:00    1.0     2.0    3.0       one        two     three        All columns filled
   2018-03-10 06:00:00    NaN     NaN    4.1      None       None      four  First two of three empty
   2018-05-17 12:00:00    NaN     NaN    NaN      None       None      None                 All empty
   2018-07-24 18:00:00    8.0     NaN    NaN     eight       None      None   Last two of three empty
   2018-10-01 00:00:00    9.0    10.0   11.0      None       None      None    Empty tags with values
   
   buggy line protocol output
    
   buggy-measurements,first_tag=one,second_tag=two,third_tag=three first=1.0,second=2.0,third=3.0 1514764800000000000
   buggy-measurements,third_tag=four third=4.1 1520661600000000000
   buggy-measurements,first_tag=eight first=8.0 1532455200000000000
   buggy-measurements first=9.0,second=10.0,third=11.0 1538352000000000000
   ```

Pull request at https://github.com/influxdata/influxdb-python/pull/694