### PR TITLE
Fix a warning under Python 3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Update test suite to add support for Python 3.7 and InfluxDB v1.6.4 and 1.7.4 (#692 thx @clslgrnc)
+- Update classifiers tuple to list in setup.py (#697 thx @Hanaasagi)
 
 ### Removed
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     tests_require=test_requires,
     install_requires=requires,
     extras_require={'test': test_requires},
-    classifiers=(
+    classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
@@ -55,5 +55,5 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Topic :: Software Development :: Libraries',
         'Topic :: Software Development :: Libraries :: Python Modules',
-    ),
+    ],
 )


### PR DESCRIPTION
`Warning: 'classifiers' should be a list, got type 'tuple'`

Related issue: https://bugs.python.org/issue19610