### PR TITLE
Mutual TLS authentication

### DIFF
--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -61,6 +61,11 @@ class InfluxDBClient(object):
     :type proxies: dict
     :param path: path of InfluxDB on the server to connect, defaults to ''
     :type path: str
+    :param cert: Path to client certificate to use for mutual TLS
+        authentication, defaults to None
+    :type cert: str
+
+    :raises ValueError: if cert is provided but ssl is disabled (set to False)
     """
 
     def __init__(self,
@@ -78,6 +83,7 @@ class InfluxDBClient(object):
                  proxies=None,
                  pool_size=10,
                  path='',
+                 cert=None,
                  ):
         """Construct a new InfluxDBClient object."""
         self.__host = host
@@ -119,6 +125,14 @@ class InfluxDBClient(object):
             self._proxies = {}
         else:
             self._proxies = proxies
+
+        if cert:
+            if not ssl:
+                raise ValueError(
+                    "Client certificate provided but ssl is disabled."
+                )
+            else:
+                self._session.cert = cert
 
         self.__baseurl = "{0}://{1}:{2}{3}".format(
             self._scheme,

--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -61,8 +61,10 @@ class InfluxDBClient(object):
     :type proxies: dict
     :param path: path of InfluxDB on the server to connect, defaults to ''
     :type path: str
-    :param cert: Path to client certificate to use for mutual TLS
-        authentication, defaults to None
+    :param cert: Path to client certificate information to use for mutual TLS
+        authentication. You can specify a local cert to use
+        as a single file containing the private key and the certificate, or as
+        a tuple of both files’ paths, defaults to None
     :type cert: str
 
     :raises ValueError: if cert is provided but ssl is disabled (set to False)

--- a/influxdb/tests/client_test.py
+++ b/influxdb/tests/client_test.py
@@ -149,6 +149,14 @@ class TestInfluxDBClient(unittest.TestCase):
                                       **{'ssl': False})
         self.assertEqual('http://my.host.fr:1886', cli._baseurl)
 
+    def test_cert(self):
+        """Test mutual TLS authentication for TestInfluxDBClient object."""
+        cli = InfluxDBClient(ssl=True, cert='/etc/pki/tls/private/dummy.crt')
+        self.assertEqual(cli._session.cert, '/etc/pki/tls/private/dummy.crt')
+
+        with self.assertRaises(ValueError):
+            cli = InfluxDBClient(cert='/etc/pki/tls/private/dummy.crt')
+
     def test_switch_database(self):
         """Test switch database in TestInfluxDBClient object."""
         cli = InfluxDBClient('host', 8086, 'username', 'password', 'database')


### PR DESCRIPTION
A recreation of #677 because I accidentally made a mess of my branch :(

With the Python requests module, it is possible to configure a client certificate to use for mutual TLS authentication, for example if an nginx instance in front of influxdb is performing the TLS termination and has a whitelist of allowed CNs.

This PR adds a new optional argument to the client constructor which passes through the path to such a client certificate to the requests session.