### PR TITLE
Docfix retention policy replication type

### DIFF
--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -660,7 +660,7 @@ class InfluxDBClient(object):
             The minimum retention period is 1 hour.
         :type duration: str
         :param replication: the replication of the retention policy
-        :type replication: str
+        :type replication: int
         :param database: the database for which the retention policy is
             created. Defaults to current client's database
         :type database: str


### PR DESCRIPTION
should be int (not str)