### PR TITLE
Added headers parameter to InfluxDBClient

### DIFF
--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -84,8 +84,10 @@ class InfluxDBClient(object):
     :param session: allow for the new client request to use an existing
         requests Session, defaults to None
     :type session: requests.Session
+    :param headers: headers to add to Requests, will add 'Content-Type'
+        and 'Accept' unless these are already present, defaults to {}
+    :type headers: dict
     :raises ValueError: if cert is provided but ssl is disabled (set to False)
-
     """
 
     def __init__(self,
@@ -106,6 +108,7 @@ class InfluxDBClient(object):
                  cert=None,
                  gzip=False,
                  session=None,
+                 headers=None,
                  ):
         """Construct a new InfluxDBClient object."""
         self.__host = host
@@ -166,10 +169,11 @@ class InfluxDBClient(object):
             self._port,
             self._path)
 
-        self._headers = {
-            'Content-Type': 'application/json',
-            'Accept': 'application/x-msgpack'
-        }
+        if headers is None:
+            headers = {}
+        headers.setdefault('Content-Type', 'application/json')
+        headers.setdefault('Accept', 'application/x-msgpack')
+        self._headers = headers
 
         self._gzip = gzip
 
@@ -390,7 +394,7 @@ class InfluxDBClient(object):
         :returns: True, if the write operation is successful
         :rtype: bool
         """
-        headers = self._headers
+        headers = self._headers.copy()
         headers['Content-Type'] = 'application/octet-stream'
 
         if params:


### PR DESCRIPTION
Hi, we'd like to use the `DataFrameClient` for writing and querying data from our Influx DB, which is accessible through an API Gateway we have setup. This requires an API key in the header of any requests for authentication. 

This commit simply adds an optional `headers` parameter to `InfluxDBClient.__init__`. The default is {} and if 'Content-Type' or 'Accept' aren't present they'll be added with the same values as before.

Note I also made another very small change in `InfluxDBClient.write` which I think provides a small bug fix, since previously the 'Content-Type' of the `self._headers` dict was getting inadvertently modified.