### PR TITLE
Fix newline in tag value cause partial commit

### DIFF
--- a/influxdb/line_protocol.py
+++ b/influxdb/line_protocol.py
@@ -54,6 +54,8 @@ def _escape_tag(tag):
         ",", "\\,"
     ).replace(
         "=", "\\="
+    ).replace(
+        "\n", "\\n"
     )
 
 

--- a/influxdb/tests/test_line_protocol.py
+++ b/influxdb/tests/test_line_protocol.py
@@ -115,6 +115,27 @@ class TestLineProtocol(unittest.TestCase):
             'test,unicode_tag=\'Привет!\' unicode_val="Привет!"\n'
         )
 
+    def test_tag_value_newline(self):
+        """Test make lines with tag value contains newline."""
+        data = {
+            "tags": {
+                "t1": "line1\nline2"
+            },
+            "points": [
+                {
+                    "measurement": "test",
+                    "fields": {
+                        "val": "hello"
+                    }
+                }
+            ]
+        }
+
+        self.assertEqual(
+            line_protocol.make_lines(data),
+            'test,t1=line1\\nline2 val="hello"\n'
+        )
+
     def test_quote_ident(self):
         """Test quote indentation in TestLineProtocol object."""
         self.assertEqual(


### PR DESCRIPTION
When a tag value contains newline(\n), the request sent to db would be splitted into two parts and the first part would fail to write to db but the second would be succeed. The reason is that before sending we do serialization(make_lines) the _escape_tag method in line_protocol.py won't handle it well, we need somehow more specific on newline instead of only handling escape character (\)

There have been an issue raised before #632 