### PR TITLE
Add support for messagepack

### DIFF
--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -281,12 +281,14 @@ class InfluxDBClient(object):
                 if not retry:
                     raise
 
-        content_type = response.headers and response.headers.get("Content-Type")
-        if content_type == "application/x-msgpack" and response.content:
+        type_header = response.headers and response.headers.get("Content-Type")
+        if type_header == "application/x-msgpack" and response.content:
             response._msgpack = msgpack.unpackb(
                 packed=response.content,
                 ext_hook=_msgpack_parse_hook,
                 raw=False)
+        else:
+            response._msgpack = None
 
         def reformat_error(response):
             if response._msgpack:
@@ -452,7 +454,7 @@ class InfluxDBClient(object):
             expected_response_code=expected_response_code
         )
 
-        data = getattr(response, '_msgpack', None)
+        data = response._msgpack
         if not data:
             if chunked:
                 return self._read_chunked_response(response)

--- a/influxdb/tests/client_test.py
+++ b/influxdb/tests/client_test.py
@@ -465,6 +465,29 @@ class TestInfluxDBClient(unittest.TestCase):
                 [{'value': 0.64, 'time': '2009-11-10T23:00:00Z'}]
             )
 
+    def test_query_msgpack(self):
+        """Test query method with a messagepack response."""
+        example_response = bytes(bytearray.fromhex(
+            "81a7726573756c74739182ac73746174656d656e745f696400a673657269"
+            "65739183a46e616d65a161a7636f6c756d6e7392a474696d65a176a67661"
+            "6c7565739192c70c05000000005d26178a019096c8cb3ff0000000000000"
+        ))
+
+        with requests_mock.Mocker() as m:
+            m.register_uri(
+                requests_mock.GET,
+                "http://localhost:8086/query",
+                request_headers={"Accept": "application/x-msgpack"},
+                headers={"Content-Type": "application/x-msgpack"},
+                content=example_response
+            )
+            rs = self.cli.query('select * from a')
+
+            self.assertListEqual(
+                list(rs.get_points()),
+                [{'v': 1.0, 'time': '2019-07-10T16:51:22.026253Z'}]
+            )
+
     def test_select_into_post(self):
         """Test SELECT.*INTO is POSTed."""
         example_response = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ pytz
 requests>=2.17.0
 six>=1.10.0
 msgpack==0.6.1
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ python-dateutil>=2.6.0
 pytz
 requests>=2.17.0
 six>=1.10.0
+msgpack==0.6.1
+


### PR DESCRIPTION
### Description
This pull request implements fetching data from InfluxDB using msgpack serialization instead of JSON. This fixes issues related to serialization ambiguities in JSON, and makes database queries faster. It does not break compatibility with older influxdb versions that do not support msgpack.

### Related issues
Closes #733
Fixes #665 
Fixes #715  
Fixes #625

### Performance
Here is a performance comparison before (JSON) and after (msgpack) this pull request, for a simple `SELECT *` request on a measurement with 2 tags and three fields of types: integer, float and string:


![performance comparison](https://user-images.githubusercontent.com/552629/61044420-e878b900-a3d8-11e9-87c5-084841d8b430.png)

Using msgpack gives a ~25% speedup.