### PR TITLE
Make batched writing support all iterables

### DIFF
--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -6,9 +6,9 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import itertools
 import time
 import random
+from itertools import chain, islice
 
 import json
 import socket
@@ -553,8 +553,8 @@ class InfluxDBClient(object):
             except StopIteration:
                 return  # ...so that we can stop if there isn't one
             # Otherwise, lazily slice the rest of the batch
-            rest = itertools.islice(iterator, size - 1)
-            yield itertools.chain(head, rest)
+            rest = islice(iterator, size - 1)
+            yield chain(head, rest)
 
     def _write_points(self,
                       points,

--- a/influxdb/tests/client_test.py
+++ b/influxdb/tests/client_test.py
@@ -265,6 +265,37 @@ class TestInfluxDBClient(unittest.TestCase):
         self.assertEqual(expected_last_body,
                          m.last_request.body.decode('utf-8'))
 
+    def test_write_points_batch_generator(self):
+        """Test write points batch from a generator for TestInfluxDBClient object.
+        """
+        dummy_points = [
+            {"measurement": "cpu_usage", "tags": {"unit": "percent"},
+             "time": "2009-11-10T23:00:00Z", "fields": {"value": 12.34}},
+            {"measurement": "network", "tags": {"direction": "in"},
+             "time": "2009-11-10T23:00:00Z", "fields": {"value": 123.00}},
+            {"measurement": "network", "tags": {"direction": "out"},
+             "time": "2009-11-10T23:00:00Z", "fields": {"value": 12.00}}
+        ]
+        dummy_points_generator = (point for point in dummy_points)
+        expected_last_body = (
+            "network,direction=out,host=server01,region=us-west "
+            "value=12.0 1257894000000000000\n"
+        )
+
+        with requests_mock.Mocker() as m:
+            m.register_uri(requests_mock.POST,
+                           "http://localhost:8086/write",
+                           status_code=204)
+            cli = InfluxDBClient(database='db')
+            cli.write_points(points=dummy_points_generator,
+                             database='db',
+                             tags={"host": "server01",
+                                   "region": "us-west"},
+                             batch_size=2)
+        self.assertEqual(m.call_count, 2)
+        self.assertEqual(expected_last_body,
+                         m.last_request.body.decode('utf-8'))
+
     def test_write_points_udp(self):
         """Test write points UDP for TestInfluxDBClient object."""
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)

--- a/influxdb/tests/client_test.py
+++ b/influxdb/tests/client_test.py
@@ -266,8 +266,7 @@ class TestInfluxDBClient(unittest.TestCase):
                          m.last_request.body.decode('utf-8'))
 
     def test_write_points_batch_generator(self):
-        """Test write points batch from a generator for TestInfluxDBClient object.
-        """
+        """Test write points batch from a generator for TestInfluxDBClient."""
         dummy_points = [
             {"measurement": "cpu_usage", "tags": {"unit": "percent"},
              "time": "2009-11-10T23:00:00Z", "fields": {"value": 12.34}},

--- a/influxdb/tests/server_tests/client_test_with_server.py
+++ b/influxdb/tests/server_tests/client_test_with_server.py
@@ -450,6 +450,33 @@ class CommonTests(ManyTestCasesWithServerMixin, unittest.TestCase):
         self.assertIn(12, net_out['series'][0]['values'][0])
         self.assertIn(12.34, cpu['series'][0]['values'][0])
 
+    def test_write_points_batch_generator(self):
+        """Test writing points in a batch from a generator."""
+        dummy_points = [
+            {"measurement": "cpu_usage", "tags": {"unit": "percent"},
+                "time": "2009-11-10T23:00:00Z", "fields": {"value": 12.34}},
+            {"measurement": "network", "tags": {"direction": "in"},
+                "time": "2009-11-10T23:00:00Z", "fields": {"value": 123.00}},
+            {"measurement": "network", "tags": {"direction": "out"},
+                "time": "2009-11-10T23:00:00Z", "fields": {"value": 12.00}}
+        ]
+        dummy_points_generator = (point for point in dummy_points)
+        self.cli.write_points(points=dummy_points_generator,
+                              tags={"host": "server01",
+                                    "region": "us-west"},
+                              batch_size=2)
+        time.sleep(5)
+        net_in = self.cli.query("SELECT value FROM network "
+                                "WHERE direction=$dir",
+                                bind_params={'dir': 'in'}
+                                ).raw
+        net_out = self.cli.query("SELECT value FROM network "
+                                 "WHERE direction='out'").raw
+        cpu = self.cli.query("SELECT value FROM cpu_usage").raw
+        self.assertIn(123, net_in['series'][0]['values'][0])
+        self.assertIn(12, net_out['series'][0]['values'][0])
+        self.assertIn(12.34, cpu['series'][0]['values'][0])
+
     def test_query(self):
         """Test querying data back from server."""
         self.assertIs(True, self.cli.write_points(dummy_point))


### PR DESCRIPTION
We have some data we write to InfluxDB from lazy iterables/generators that don't necessarily support indexing or have a length that can be known up-front.

This is a second attempt at #408. It includes a fix for Python 3.7 compatibility (catches the `StopIteration`).