### PR TITLE
Fix make_lines excludes fields with empty strings (#655)

### DIFF
--- a/influxdb/line_protocol.py
+++ b/influxdb/line_protocol.py
@@ -91,9 +91,11 @@ def _is_float(value):
 
 
 def _escape_value(value):
-    value = _get_unicode(value)
+    if value is None:
+        return ''
 
-    if isinstance(value, text_type) and value != '':
+    value = _get_unicode(value)
+    if isinstance(value, text_type):
         return quote_ident(value)
     elif isinstance(value, integer_types) and not isinstance(value, bool):
         return str(value) + 'i'

--- a/influxdb/tests/test_line_protocol.py
+++ b/influxdb/tests/test_line_protocol.py
@@ -116,7 +116,7 @@ class TestLineProtocol(unittest.TestCase):
         )
 
     def test_make_lines_empty_field_string(self):
-        """Test make lines with an empty string field in TestLineProtocol object."""
+        """Test make lines with an empty string field."""
         data = {
             "points": [
                 {

--- a/influxdb/tests/test_line_protocol.py
+++ b/influxdb/tests/test_line_protocol.py
@@ -115,6 +115,24 @@ class TestLineProtocol(unittest.TestCase):
             'test,unicode_tag=\'Привет!\' unicode_val="Привет!"\n'
         )
 
+    def test_make_lines_empty_field_string(self):
+        """Test make lines with an empty string field in TestLineProtocol object."""
+        data = {
+            "points": [
+                {
+                    "measurement": "test",
+                    "fields": {
+                        "string": "",
+                    }
+                }
+            ]
+        }
+
+        self.assertEqual(
+            line_protocol.make_lines(data),
+            'test string=""\n'
+        )
+
     def test_tag_value_newline(self):
         """Test make lines with tag value contains newline."""
         data = {


### PR DESCRIPTION
Converting to unicode required something to be done with None values. They were
converted to empty strings which were subsequently ignored. This makes it
impossible to write an explicitly empty string, which should be possible. This
change distinguishes between None and empty strings.

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Builds are passing
- [x] New tests have been added (for feature additions)
