### PR TITLE
fix: resolving raising exception when calling the commit function without any SeriesHelper

### DIFF
--- a/influxdb/influxdb08/helper.py
+++ b/influxdb/influxdb08/helper.py
@@ -73,7 +73,7 @@ class SeriesHelper(object):
             if cls._autocommit and not cls._client:
                 raise AttributeError(
                     'In {0}, autocommit is set to True, but no client is set.'
-                    .format(cls.__name__))
+                        .format(cls.__name__))
 
             try:
                 cls._bulk_size = getattr(_meta, 'bulk_size')
@@ -128,6 +128,10 @@ class SeriesHelper(object):
         """
         if not client:
             client = cls._client
+
+        if not cls._datapoints:
+            cls._datapoints = defaultdict(list)
+
         rtn = client.write_points(cls._json_body_())
         cls._reset_()
         return rtn


### PR DESCRIPTION
If any SeriesHelper is not generated, calling the commit function makes raising exception because _datapoints is None.

It is hard to find the reason of this error. it is because reviewing influxdb-python's code is needed.

So, I've fixed that if _datapoints is None in the commit function, _datapoints is set to defaultdict to avoid raising error.

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Builds are passing
- [ ] New tests have been added (for feature additions)
=> it is not feature addition but covering an exception.