### PR TITLE
fix: Calling commit and _json_body make raising an exception when any datapoints are not added.

### DIFF
--- a/influxdb/helper.py
+++ b/influxdb/helper.py
@@ -154,6 +154,8 @@ class SeriesHelper(object):
         :return: JSON body of these datapoints.
         """
         json = []
+        if not cls.__initialized__:
+            cls._reset_()
         for series_name, data in six.iteritems(cls._datapoints):
             for point in data:
                 json_point = {

--- a/influxdb/influxdb08/helper.py
+++ b/influxdb/influxdb08/helper.py
@@ -139,6 +139,8 @@ class SeriesHelper(object):
         :return: JSON body of the datapoints.
         """
         json = []
+        if not cls.__initialized__:
+            cls._reset_()
         for series_name, data in six.iteritems(cls._datapoints):
             json.append({'name': series_name,
                          'columns': cls._fields,

--- a/influxdb/tests/helper_test.py
+++ b/influxdb/tests/helper_test.py
@@ -48,7 +48,7 @@ class TestSeriesHelper(unittest.TestCase):
         TestSeriesHelper.MySeriesHelper = MySeriesHelper
 
     def setUp(self):
-        """Check not initialized datapoints's not raising exception and resetting helper"""
+        """Check not initialized datapoints's not raising exception and resetting helper."""
         super(TestSeriesHelper, self).setUp()
         self.assertEqual(
             TestSeriesHelper.MySeriesHelper._json_body_(),

--- a/influxdb/tests/helper_test.py
+++ b/influxdb/tests/helper_test.py
@@ -48,8 +48,10 @@ class TestSeriesHelper(unittest.TestCase):
         TestSeriesHelper.MySeriesHelper = MySeriesHelper
 
     def setUp(self):
-        """Check not initialized datapoints's not raising exception
-         and resetting helper."""
+        """
+        Check not initialized datapoints's not raising exception
+        and resetting helper.
+        """
         super(TestSeriesHelper, self).setUp()
         self.assertEqual(
             TestSeriesHelper.MySeriesHelper._json_body_(),

--- a/influxdb/tests/helper_test.py
+++ b/influxdb/tests/helper_test.py
@@ -48,7 +48,7 @@ class TestSeriesHelper(unittest.TestCase):
         TestSeriesHelper.MySeriesHelper = MySeriesHelper
 
     def setUp(self):
-        """Check that MySeriesHelper has empty datapoints"""
+        """Check that MySeriesHelper has empty datapoints."""
         super(TestSeriesHelper, self).setUp()
         self.assertEqual(
             TestSeriesHelper.MySeriesHelper._json_body_(),

--- a/influxdb/tests/helper_test.py
+++ b/influxdb/tests/helper_test.py
@@ -48,11 +48,12 @@ class TestSeriesHelper(unittest.TestCase):
         TestSeriesHelper.MySeriesHelper = MySeriesHelper
 
     def setUp(self):
+        """Check not initialized datapoints's not raising exception and resetting helper"""
         super(TestSeriesHelper, self).setUp()
         self.assertEqual(
             TestSeriesHelper.MySeriesHelper._json_body_(),
             [],
-            'Initializing helper and resetting helper in teardown did not empty datapoints.')
+            'Resetting helper in teardown did not empty datapoints.')
 
     def tearDown(self):
         """Deconstruct the TestSeriesHelper object."""

--- a/influxdb/tests/helper_test.py
+++ b/influxdb/tests/helper_test.py
@@ -47,6 +47,13 @@ class TestSeriesHelper(unittest.TestCase):
 
         TestSeriesHelper.MySeriesHelper = MySeriesHelper
 
+    def setUp(self):
+        super(TestSeriesHelper, self).setUp()
+        self.assertEqual(
+            TestSeriesHelper.MySeriesHelper._json_body_(),
+            [],
+            'Initializing helper and resetting helper in teardown did not empty datapoints.')
+
     def tearDown(self):
         """Deconstruct the TestSeriesHelper object."""
         super(TestSeriesHelper, self).tearDown()

--- a/influxdb/tests/helper_test.py
+++ b/influxdb/tests/helper_test.py
@@ -48,7 +48,8 @@ class TestSeriesHelper(unittest.TestCase):
         TestSeriesHelper.MySeriesHelper = MySeriesHelper
 
     def setUp(self):
-        """Check not initialized datapoints's not raising exception and resetting helper."""
+        """Check not initialized datapoints's not raising exception
+         and resetting helper."""
         super(TestSeriesHelper, self).setUp()
         self.assertEqual(
             TestSeriesHelper.MySeriesHelper._json_body_(),

--- a/influxdb/tests/helper_test.py
+++ b/influxdb/tests/helper_test.py
@@ -48,10 +48,7 @@ class TestSeriesHelper(unittest.TestCase):
         TestSeriesHelper.MySeriesHelper = MySeriesHelper
 
     def setUp(self):
-        """
-        Check not initialized datapoints's not raising exception
-        and resetting helper.
-        """
+        """Check that MySeriesHelper has empty datapoints"""
         super(TestSeriesHelper, self).setUp()
         self.assertEqual(
             TestSeriesHelper.MySeriesHelper._json_body_(),


### PR DESCRIPTION
If any SerialHelper is not generated, calling the commit function makes raising an exception because _datapoints is not allocated.

It is hard to find the reason of this error. it is because reviewing influxdb-python's code is needed.

I think that it is important that is producing predictable results. Results when calling first time is needed to equal to calling resetting datapoints in json_body.

So, I've fixed that if not initialized when calling _json_body() function, _datapoints is reset to avoid raising error.

In Unittest, the setup function is added. When calling setup function firstly, __initialized__ is False and _datapoints is not assigned. But, because of this commit, it is OK.

Contacts: Keunhyun Oh <keunhyun.oh@ahnlab.com>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Builds are passing
- [x] New tests have been added (for feature additions)
