### PR TITLE
Bugfix dropna in DataFrameClient. Add unit test.

### DIFF
--- a/influxdb/_dataframe_client.py
+++ b/influxdb/_dataframe_client.py
@@ -203,7 +203,8 @@ class DataFrameClient(InfluxDBClient):
     def _to_dataframe(self, rs, dropna=True):
         result = defaultdict(list)
         if isinstance(rs, list):
-            return map(self._to_dataframe, rs)
+            return map(self._to_dataframe, rs,
+                       [dropna for _ in range(len(rs))])
 
         for key, data in rs.items():
             name, tags = key


### PR DESCRIPTION
Fix dropna
---
Bugfix : when running multiple queries using the DataFrameClient, the dropna argument is not properly mapped.  Added a specific test that fails when the bugfix is not included.

##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Builds are passing
- [x] New tests have been added (for feature additions)
