### PR TITLE
Add functions to SHOW TAG KEYS and SHOW FIELD KEYS

### DIFF
--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -685,9 +685,7 @@ class InfluxDBClient(object):
 
             >> dbs = client.get_list_tags()
             >> dbs
-            [{u'name': u'measurements1'},
-             {u'name': u'measurements2'},
-             {u'name': u'measurements3'}]
+            [{u'tagKey': u'tag1'}, {u'tagKey': u'tag2'}, {u'tagKey': u'tag3'}]
         """
         return list(self.query("SHOW TAG KEYS").get_points())
   
@@ -703,9 +701,8 @@ class InfluxDBClient(object):
 
             >> dbs = client.get_list_fields()
             >> dbs
-            [{u'name': u'measurements1'},
-             {u'name': u'measurements2'},
-             {u'name': u'measurements3'}]
+            [{u'fieldKey': u'field1', u'fieldType': u'type1'}, {u'fieldKey': u'field2', u'fieldType': u'type2'},
+             {u'fieldKey': u'field3', u'fieldType': u'type3'}]
         """
         return list(self.query("SHOW FIELD KEYS").get_points())
     

--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -690,6 +690,24 @@ class InfluxDBClient(object):
              {u'name': u'measurements3'}]
         """
         return list(self.query("SHOW TAG KEYS").get_points())
+  
+    def get_list_fields(self):
+        """Get the list of fields in InfluxDB.
+
+        :returns: all fields in InfluxDB
+        :rtype: list of dictionaries
+
+        :Example:
+
+        ::
+
+            >> dbs = client.get_list_fields()
+            >> dbs
+            [{u'name': u'measurements1'},
+             {u'name': u'measurements2'},
+             {u'name': u'measurements3'}]
+        """
+        return list(self.query("SHOW FIELD KEYS").get_points())
     
     def drop_measurement(self, measurement):
         """Drop a measurement from InfluxDB.

--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -673,6 +673,24 @@ class InfluxDBClient(object):
         """
         return list(self.query("SHOW MEASUREMENTS").get_points())
 
+    def get_list_tags(self):
+        """Get the list of tags in InfluxDB.
+
+        :returns: all tags in InfluxDB
+        :rtype: list of dictionaries
+
+        :Example:
+
+        ::
+
+            >> dbs = client.get_list_tags()
+            >> dbs
+            [{u'name': u'measurements1'},
+             {u'name': u'measurements2'},
+             {u'name': u'measurements3'}]
+        """
+        return list(self.query("SHOW TAG KEYS").get_points())
+    
     def drop_measurement(self, measurement):
         """Drop a measurement from InfluxDB.
 


### PR DESCRIPTION
Then supported these 2 new functions : SHOW TAG KEYS & SHOW FIELD KEYS
like InfluxDB show field keys in query-language
_https://docs.influxdata.com/influxdb/v1.7/query_language/schema_exploration/#show-field-keys_

[x]Controlled

If you accept my contribution to this feature