### PR TITLE
Require pandas for tests

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,5 @@
 nose
 nose-cov
 mock
+pandas==0.20.1
 requests-mock


### PR DESCRIPTION
Some tests fail if pandas isn’t available to import. Add it to
`test-requirements.txt` accordingly.

Fixes GH-799.

---
##### Contributor checklist
- [ ] Builds are passing
- [x] New tests have been added (for feature additions)