### PR TITLE
feat(client): re-add support for 'show series' from legacy PR #357. Closes #353

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+
+### Changed
+
+## [v5.2.4] - 2020-04-10
+
+### Added
 - Add mypy testing framework (#756)
 - Add support for messagepack (#734 thx @lovasoa)
+- Add support for 'show series' (#357 thx @gaker)
 
 ### Changed
 - Clean up stale CI config (#755)

--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -640,7 +640,8 @@ class InfluxDBClient(object):
 
     def get_list_series(self, database=None, measurement=None, tags=None):
         """
-        The SHOW SERIES query returns the distinct series in your database.
+        Query SHOW SERIES returns the distinct series in your database.
+
         FROM and WHERE clauses are optional.
 
         :param measurement: Show all series from a measurement
@@ -661,7 +662,15 @@ class InfluxDBClient(object):
             query_str += ' WHERE ' + ' and '.join(["{0}='{1}'".format(k, v)
                                                    for k, v in tags.items()])
 
-        return list(itertools.chain.from_iterable([x.values() for x in (self.query(query_str, database=database).get_points())]))
+        return list(
+            itertools.chain.from_iterable(
+                [
+                    x.values()
+                    for x in (self.query(query_str, database=database)
+                              .get_points())
+                ]
+            )
+        )
 
     def create_database(self, dbname):
         """Create a new database in InfluxDB.

--- a/influxdb/tests/client_test.py
+++ b/influxdb/tests/client_test.py
@@ -705,8 +705,8 @@ class TestInfluxDBClient(unittest.TestCase):
         with _mocked_session(self.cli, 'get', 200, json.dumps(data)):
             self.assertListEqual(
                 self.cli.get_list_series(),
-                [{'key': 'cpu_load_short,host=server01,region=us-west'},
-                 {'key': 'memory_usage,host=server02,region=us-east'}])
+                ['cpu_load_short,host=server01,region=us-west',
+                 'memory_usage,host=server02,region=us-east'])
 
     def test_get_list_series_with_measurement(self):
 

--- a/influxdb/tests/client_test.py
+++ b/influxdb/tests/client_test.py
@@ -689,6 +689,64 @@ class TestInfluxDBClient(unittest.TestCase):
                 [{'name': 'cpu'}, {'name': 'disk'}]
             )
 
+    def test_get_list_series(self):
+
+        data = {'results': [
+            {'series': [
+                {
+                    'values': [
+                        ['cpu_load_short,host=server01,region=us-west'],
+                        ['memory_usage,host=server02,region=us-east']],
+                    'columns': ['key']
+                }
+            ]}
+        ]}
+
+        with _mocked_session(self.cli, 'get', 200, json.dumps(data)):
+            self.assertListEqual(
+                self.cli.get_list_series(),
+                [{'key': 'cpu_load_short,host=server01,region=us-west'},
+                 {'key': 'memory_usage,host=server02,region=us-east'}])
+
+    def test_get_list_series_with_measurement(self):
+
+        data = {'results': [
+            {'series': [
+                {
+                    'values': [
+                        ['cpu_load_short,host=server01,region=us-west']],
+                    'columns': ['key']
+                }
+            ]}
+        ]}
+
+        with _mocked_session(self.cli, 'get', 200, json.dumps(data)):
+            self.assertListEqual(
+                self.cli.get_list_series(measurement='cpu_load_short'),
+                ['cpu_load_short,host=server01,region=us-west'])
+
+    def test_get_list_series_with_tags(self):
+        data = {'results': [
+            {'series': [
+                {
+                    'values': [
+                        ['cpu_load_short,host=server01,region=us-west']],
+                    'columns': ['key']
+                }
+            ]}
+        ]}
+
+        with _mocked_session(self.cli, 'get', 200, json.dumps(data)):
+            self.assertListEqual(
+                self.cli.get_list_series(tags={'region': 'us-west'}),
+                ['cpu_load_short,host=server01,region=us-west'])
+
+    @raises(Exception)
+    def test_get_list_series_fails(self):
+        cli = InfluxDBClient('host', 8086, 'username', 'password')
+        with _mocked_session(cli, 'get', 401):
+            cli.get_list_series()
+
     def test_create_retention_policy_default(self):
         """Test create default ret policy for TestInfluxDBClient object."""
         example_response = '{"results":[{}]}'

--- a/influxdb/tests/client_test.py
+++ b/influxdb/tests/client_test.py
@@ -690,7 +690,7 @@ class TestInfluxDBClient(unittest.TestCase):
             )
 
     def test_get_list_series(self):
-
+        """Test get a list of series from the database."""
         data = {'results': [
             {'series': [
                 {
@@ -709,7 +709,7 @@ class TestInfluxDBClient(unittest.TestCase):
                  'memory_usage,host=server02,region=us-east'])
 
     def test_get_list_series_with_measurement(self):
-
+        """Test get a list of series from the database by filter."""
         data = {'results': [
             {'series': [
                 {
@@ -726,6 +726,7 @@ class TestInfluxDBClient(unittest.TestCase):
                 ['cpu_load_short,host=server01,region=us-west'])
 
     def test_get_list_series_with_tags(self):
+        """Test get a list of series from the database by tags."""
         data = {'results': [
             {'series': [
                 {
@@ -743,6 +744,7 @@ class TestInfluxDBClient(unittest.TestCase):
 
     @raises(Exception)
     def test_get_list_series_fails(self):
+        """Test get a list of series from the database but fail."""
         cli = InfluxDBClient('host', 8086, 'username', 'password')
         with _mocked_session(cli, 'get', 401):
             cli.get_list_series()

--- a/influxdb/tests/server_tests/client_test_with_server.py
+++ b/influxdb/tests/server_tests/client_test_with_server.py
@@ -817,6 +817,64 @@ GROUP BY tag_1').get_points())
         ]
         self.cli.write_points(pts)
 
+    def test_get_list_series(self):
+
+        dummy_points = [
+            {
+                "measurement": "cpu_load_short",
+                "tags": {
+                    "host": "server01",
+                    "region": "us-west"
+                },
+                "time": "2009-11-10T23:00:00.123456Z",
+                "fields": {
+                    "value": 0.64
+                }
+            }
+        ]
+
+        dummy_points_2 = [
+            {
+                "measurement": "memory_usage",
+                "tags": {
+                    "host": "server02",
+                    "region": "us-east"
+                },
+                "time": "2009-11-10T23:00:00.123456Z",
+                "fields": {
+                    "value": 80
+                }
+            }
+        ]
+
+        self.cli.write_points(dummy_points)
+        self.cli.write_points(dummy_points_2)
+
+        self.assertEquals(
+            self.cli.get_list_series(),
+            ['cpu_load_short,host=server01,region=us-west',
+             'memory_usage,host=server02,region=us-east']
+        )
+
+        self.assertEquals(
+            self.cli.get_list_series(measurement='memory_usage'),
+            ['memory_usage,host=server02,region=us-east']
+        )
+
+        self.assertEquals(
+            self.cli.get_list_series(measurement='memory_usage'),
+            ['memory_usage,host=server02,region=us-east']
+        )
+
+        self.assertEquals(
+            self.cli.get_list_series(tags={'host': 'server02'}),
+            ['memory_usage,host=server02,region=us-east'])
+
+        self.assertEquals(
+            self.cli.get_list_series(
+                measurement='cpu_load_short', tags={'host': 'server02'}),
+            [])
+
 
 @skip_server_tests
 class UdpTests(ManyTestCasesWithServerMixin, unittest.TestCase):

--- a/influxdb/tests/server_tests/client_test_with_server.py
+++ b/influxdb/tests/server_tests/client_test_with_server.py
@@ -818,7 +818,7 @@ GROUP BY tag_1').get_points())
         self.cli.write_points(pts)
 
     def test_get_list_series(self):
-
+        """Test get a list of series from the database."""
         dummy_points = [
             {
                 "measurement": "cpu_load_short",


### PR DESCRIPTION
Closes #353.

This PR merges in the changes from #357 which grew stale over the course of 4 years. Also look to incorporate the feedback from previous commits.
