### PR TITLE
feat(client): allow custom requests session in InfluxDBClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add mypy testing framework (#756)
 - Add support for messagepack (#734 thx @lovasoa)
 - Add support for 'show series' (#357 thx @gaker)
+- Add support for custom request session in InfluxDBClient (#360 thx @dschien)
 
 ### Changed
 - Clean up stale CI config (#755)

--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -70,6 +70,9 @@ class InfluxDBClient(object):
         as a single file containing the private key and the certificate, or as
         a tuple of both files’ paths, defaults to None
     :type cert: str
+    :param session: allow for the new client request to use an existing
+        requests Session, defaults to None
+    :type session: requests.Session
 
     :raises ValueError: if cert is provided but ssl is disabled (set to False)
     """
@@ -90,6 +93,7 @@ class InfluxDBClient(object):
                  pool_size=10,
                  path='',
                  cert=None,
+                 session=None,
                  ):
         """Construct a new InfluxDBClient object."""
         self.__host = host
@@ -104,7 +108,11 @@ class InfluxDBClient(object):
 
         self.__use_udp = use_udp
         self.__udp_port = udp_port
-        self._session = requests.Session()
+
+        if not session:
+            session = requests.Session()
+
+        self._session = session
         adapter = requests.adapters.HTTPAdapter(
             pool_connections=int(pool_size),
             pool_maxsize=int(pool_size)


### PR DESCRIPTION
Closes #360.

Closing a legacy PR, this allows for the user to specify a custom session for the `InfluxDBClient`.