### PR TITLE
Refactor `tutorial_udp` example for timestamps

### DIFF
--- a/examples/tutorial_udp.py
+++ b/examples/tutorial_udp.py
@@ -29,18 +29,19 @@ def main(uport):
             "host": "server01",
             "region": "us-west"
         },
-        "time": "2009-11-10T23:00:00Z",
         "points": [{
             "measurement": "cpu_load_short",
             "fields": {
                 "value": 0.64
-            }
+            },
+            "time": "2009-11-10T23:00:00Z",
         },
-            {
-                "measurement": "cpu_load_short",
-                "fields": {
-                    "value": 0.67
-                }
+        {
+            "measurement": "cpu_load_short",
+            "fields": {
+                "value": 0.67
+            },
+            "time": "2009-11-10T23:05:00Z"
         }]
     }
 


### PR DESCRIPTION
- `time` key should be within each datapoint
- Align the Points
- Insert distinct timestamps to observe difference in insertion

- This PR addresses #788 regarding the structure of the data when
inserting via UDP.
- The original documentation contributed by me that took the structure of
the `tutorial.py` as base. However, upon testing, the timestamp in the
example are not written (2020 is written as opposed to 2009).

- Tested for `influxdb-python` v5.2.3 and InfluxDB v1.6.1

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Builds are passing
- [ ] New tests have been added (for feature additions)
