### PR TITLE
chore(line_protocol): update repr value of floats to properly handle precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update make_lines section in line_protocol.py to split out core function (#375 thx @aisbaa)
 - Fix nanosecond time resolution for points (#407 thx @AndreCAndersen && @clslgrnc)
 - Fix import of distutils.spawn (#805 thx @Hawk777)
+- Update repr of float values including properly handling of boolean (#488 thx @ghost)
 
 ### Removed
 

--- a/influxdb/line_protocol.py
+++ b/influxdb/line_protocol.py
@@ -112,6 +112,9 @@ def _escape_value(value):
     if isinstance(value, integer_types) and not isinstance(value, bool):
         return str(value) + 'i'
 
+    if isinstance(value, bool):
+        return str(value)
+
     if _is_float(value):
         return repr(float(value))
 

--- a/influxdb/line_protocol.py
+++ b/influxdb/line_protocol.py
@@ -113,7 +113,7 @@ def _escape_value(value):
         return str(value) + 'i'
 
     if _is_float(value):
-        return repr(value)
+        return repr(float(value))
 
     return str(value)
 

--- a/influxdb/tests/test_line_protocol.py
+++ b/influxdb/tests/test_line_protocol.py
@@ -6,10 +6,12 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from datetime import datetime
 import unittest
-from pytz import UTC, timezone
 
+from datetime import datetime
+from decimal import Decimal
+
+from pytz import UTC, timezone
 from influxdb import line_protocol
 
 
@@ -158,6 +160,23 @@ class TestLineProtocol(unittest.TestCase):
                     "measurement": "test",
                     "fields": {
                         "float_val": 1.0000000000000009,
+                    }
+                }
+            ]
+        }
+        self.assertEqual(
+            line_protocol.make_lines(data),
+            'test float_val=1.0000000000000009\n'
+        )
+
+    def test_float_with_long_decimal_fraction_as_type_decimal(self):
+        """Ensure precision is preserved when casting Decimal into strings."""
+        data = {
+            "points": [
+                {
+                    "measurement": "test",
+                    "fields": {
+                        "float_val": Decimal(1.0000000000000009),
                     }
                 }
             ]

--- a/influxdb/tests/test_line_protocol.py
+++ b/influxdb/tests/test_line_protocol.py
@@ -176,12 +176,12 @@ class TestLineProtocol(unittest.TestCase):
                 {
                     "measurement": "test",
                     "fields": {
-                        "float_val": Decimal(1.0000000000000009),
+                        "float_val": Decimal(0.8289445733333332),
                     }
                 }
             ]
         }
         self.assertEqual(
             line_protocol.make_lines(data),
-            'test float_val=1.0000000000000009\n'
+            'test float_val=0.8289445733333332\n'
         )


### PR DESCRIPTION
Closes #488.

Based on the conversation back on #488 we take into account longer decimal and float values and try to represent their precision accordingly.