### PR TITLE
chore(client): ensure UDP port is actually an int. Closes #651.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update DataFrameClient to fix faulty empty tags (#770 thx @michelfripiat)
 - Update DataFrameClient to properly return `dropna` values (#778 thx @jgspiro)
 - Update DataFrameClient to test for pd.DataTimeIndex before blind conversion (#623 thx @testforvin)
+- Update client to type-set UDP port to int (#651 thx @yifeikong)
 
 ### Removed
 

--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -107,7 +107,7 @@ class InfluxDBClient(object):
         self._verify_ssl = verify_ssl
 
         self.__use_udp = use_udp
-        self.__udp_port = udp_port
+        self.__udp_port = int(udp_port)
 
         if not session:
             session = requests.Session()


### PR DESCRIPTION
Closes #651.

Add an `int` conversion to the UDP port similar to the HTTP port.