### PR TITLE
feat(client): add support for context managers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update client to type-set UDP port to int (#651 thx @yifeikong)
 - Update batched writing support for all iterables (#746 thx @JayH5)
 - Update SeriesHelper to enable class instantiation when not initialized (#772 thx @ocworld)
+- Update UDP test case to add proper timestamp to datapoints (#808 thx @shantanoo-desai)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add gzip compression for post and response data (#732 thx @KEClaytor)
 - Add support for chunked responses in ResultSet (#753 and #538 thx @hrbonz && @psy0rz)
 - Add support for empty string fields (#766 thx @gregschrock)
+- Add support for context managers to InfluxDBClient (#721 thx @JustusAdam)
 
 ### Changed
 - Clean up stale CI config (#755)

--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -35,6 +35,9 @@ class InfluxDBClient(object):
     connect to InfluxDB. Requests can be made to InfluxDB directly through
     the client.
 
+    The client supports the use as a `context manager
+    <https://docs.python.org/3/reference/datamodel.html#context-managers>`_.
+
     :param host: hostname to connect to InfluxDB, defaults to 'localhost'
     :type host: str
     :param port: port to connect to InfluxDB, defaults to 8086
@@ -78,6 +81,7 @@ class InfluxDBClient(object):
         requests Session, defaults to None
     :type session: requests.Session
     :raises ValueError: if cert is provided but ssl is disabled (set to False)
+
     """
 
     def __init__(self,
@@ -164,6 +168,14 @@ class InfluxDBClient(object):
         }
 
         self._gzip = gzip
+
+    def __enter__(self):
+        """Enter function as used by context manager."""
+        pass
+
+    def __exit__(self, _exc_type, _exc_value, _traceback):
+        """Exit function as used by context manager."""
+        self.close()
 
     @property
     def _baseurl(self):


### PR DESCRIPTION
Closes #721.

Add ability to define `InfluxDBClient` with a context manager:

https://www.geeksforgeeks.org/context-manager-in-python/