### PR TITLE
remove msgpack pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ python-dateutil>=2.6.0
 pytz
 requests>=2.17.0
 six>=1.10.0
-msgpack==0.6.1
+msgpack


### PR DESCRIPTION
The hard lock prevents this from being co-installed with many other
packages.  For instance, it's preventing it from being included in
openstack (which is on 0.6.2 and working on 1.0.0 now).

Signed-off-by: Matthew Thode <mthode@mthode.org>

---
##### Contributor checklist
- [ ] Builds are passing
- [×] New tests have been added (for feature additions)
