### PR TITLE
Allow skipping DataFrameClient import

### DIFF
--- a/docs/source/api-documentation.rst
+++ b/docs/source/api-documentation.rst
@@ -10,6 +10,10 @@ To connect to a InfluxDB, you must create a
 connects to InfluxDB on ``localhost`` with the default
 ports. The below instantiation statements are all equivalent::
 
+    # Set INFLUXDB_NO_DATAFRAME_CLIENT to skip the expensive DataFrameClient
+    # import in cases where you only need the basic InfluxDBClient.
+    os.environ["INFLUXDB_NO_DATAFRAME_CLIENT"] = "1"
+
     from influxdb import InfluxDBClient
 
     # using Http

--- a/examples/tutorial.py
+++ b/examples/tutorial.py
@@ -3,6 +3,8 @@
 
 import argparse
 
+import os
+os.environ["INFLUXDB_NO_DATAFRAME_CLIENT"] = "1"
 from influxdb import InfluxDBClient
 
 

--- a/influxdb/__init__.py
+++ b/influxdb/__init__.py
@@ -6,16 +6,20 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import os
+
 from .client import InfluxDBClient
-from .dataframe_client import DataFrameClient
 from .helper import SeriesHelper
 
 
 __all__ = [
     'InfluxDBClient',
-    'DataFrameClient',
     'SeriesHelper',
 ]
+
+if "INFLUXDB_NO_DATAFRAME_CLIENT" not in os.environ:
+   from .dataframe_client import DataFrameClient
+   __all__.append( "DataFrameClient" )
 
 
 __version__ = '5.3.0'


### PR DESCRIPTION
Importing the DataFrameClient can take quite a while,
especially when the source files aren't yet loaded into
the page cache.

This patch adds an environment variable, INFLUXDB_NO_DATAFRAME_CLIENT,
to allow users of this package to skip this import in cases where
they don't need it.

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Builds are passing
- [ ] New tests have been added (for feature additions)
