### PR TITLE
feat: add support for custom authorization token

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -31,3 +31,9 @@ Tutorials - UDP
 
 .. literalinclude:: ../../examples/tutorial_udp.py
    :language: python
+
+Tutorials - Authorization by Token
+===============
+
+.. literalinclude:: ../../examples/tutorial_authorization.py
+   :language: python

--- a/examples/tutorial_authorization.py
+++ b/examples/tutorial_authorization.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+"""Tutorial how to authorize InfluxDB client by custom Authorization token."""
+
+import argparse
+from influxdb import InfluxDBClient
+
+
+def main(token='my-token'):
+    """Instantiate a connection to the InfluxDB."""
+    client = InfluxDBClient(username=None, password=None,
+                            headers={"Authorization": token})
+
+    print("Use authorization token: " + token)
+
+    version = client.ping()
+    print("Successfully connected to InfluxDB: " + version)
+    pass
+
+
+def parse_args():
+    """Parse the args from main."""
+    parser = argparse.ArgumentParser(
+        description='example code to play with InfluxDB')
+    parser.add_argument('--token', type=str, required=False,
+                        default='my-token',
+                        help='Authorization token for the proxy that is ahead the InfluxDB.')
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    args = parse_args()
+    main(token=args.token)

--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -328,10 +328,11 @@ class InfluxDBClient(object):
         _try = 0
         while retry:
             try:
+                auth = (self._username, self._password)
                 response = self._session.request(
                     method=method,
                     url=url,
-                    auth=(self._username, self._password),
+                    auth=auth if None not in auth else None,
                     params=params,
                     data=data,
                     stream=stream,

--- a/influxdb/tests/client_test.py
+++ b/influxdb/tests/client_test.py
@@ -1427,6 +1427,60 @@ class TestInfluxDBClient(unittest.TestCase):
                     'values': [['qps'], ['uptime'], ['df'], ['mount']]
                 }]}).__repr__())
 
+    def test_auth_default(self):
+        """Test auth with default settings."""
+        with requests_mock.Mocker() as m:
+            m.register_uri(
+                requests_mock.GET,
+                "http://localhost:8086/ping",
+                status_code=204,
+                headers={'X-Influxdb-Version': '1.2.3'}
+            )
+
+            cli = InfluxDBClient()
+            cli.ping()
+
+            self.assertEqual(m.last_request.headers["Authorization"],
+                             "Basic cm9vdDpyb290")
+
+    def test_auth_username_password_none(self):
+        """Test auth with not defined username or password."""
+        with requests_mock.Mocker() as m:
+            m.register_uri(
+                requests_mock.GET,
+                "http://localhost:8086/ping",
+                status_code=204,
+                headers={'X-Influxdb-Version': '1.2.3'}
+            )
+
+            cli = InfluxDBClient(username=None, password=None)
+            cli.ping()
+            self.assertFalse('Authorization' in m.last_request.headers)
+
+            cli = InfluxDBClient(username=None)
+            cli.ping()
+            self.assertFalse('Authorization' in m.last_request.headers)
+
+            cli = InfluxDBClient(password=None)
+            cli.ping()
+            self.assertFalse('Authorization' in m.last_request.headers)
+
+    def test_auth_token(self):
+        """Test auth with custom authorization header."""
+        with requests_mock.Mocker() as m:
+            m.register_uri(
+                requests_mock.GET,
+                "http://localhost:8086/ping",
+                status_code=204,
+                headers={'X-Influxdb-Version': '1.2.3'}
+            )
+
+            cli = InfluxDBClient(username=None, password=None,
+                                 headers={"Authorization": "my-token"})
+            cli.ping()
+            self.assertEqual(m.last_request.headers["Authorization"],
+                             "my-token")
+
 
 class FakeClient(InfluxDBClient):
     """Set up a fake client instance of InfluxDBClient."""

--- a/influxdb/tests/client_test.py
+++ b/influxdb/tests/client_test.py
@@ -1443,6 +1443,23 @@ class TestInfluxDBClient(unittest.TestCase):
             self.assertEqual(m.last_request.headers["Authorization"],
                              "Basic cm9vdDpyb290")
 
+    def test_auth_username_password(self):
+        """Test auth with custom username and password."""
+        with requests_mock.Mocker() as m:
+            m.register_uri(
+                requests_mock.GET,
+                "http://localhost:8086/ping",
+                status_code=204,
+                headers={'X-Influxdb-Version': '1.2.3'}
+            )
+
+            cli = InfluxDBClient(username='my-username',
+                                 password='my-password')
+            cli.ping()
+
+            self.assertEqual(m.last_request.headers["Authorization"],
+                             "Basic bXktdXNlcm5hbWU6bXktcGFzc3dvcmQ=")
+
     def test_auth_username_password_none(self):
         """Test auth with not defined username or password."""
         with requests_mock.Mocker() as m:

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ commands = pydocstyle --count -ve examples influxdb
 [testenv:coverage]
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
-       pandas
+       pandas==0.24.2
        coverage
        numpy
 commands = nosetests -v --with-coverage --cover-html --cover-package=influxdb


### PR DESCRIPTION
Following code should produce request with header: `Authorization=my-token`:

```python
client = InfluxDBClient(username=None, 
                        password=None,
                        headers={"Authorization": "my-token"})

version = client.ping()
```

but current implementation always use HTTP basic auth even if an `username` and  a `password` are not specified:
https://github.com/influxdata/influxdb-python/blob/fc0235e2c07abf09eff4de7f6396a17aca1080f1/influxdb/client.py#L334

If the InfluxDB is behind a proxy, the client cannot connect into InfluxDB since both use the Authorization header.

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Builds are passing
- [x] New tests have been added (for feature additions)
