### PR TITLE
Fixed gzip tests by comparing decompressed values

### DIFF
--- a/influxdb/tests/client_test.py
+++ b/influxdb/tests/client_test.py
@@ -248,8 +248,8 @@ class TestInfluxDBClient(unittest.TestCase):
                 )
 
             self.assertEqual(
-                m.last_request.body,
-                compressed.getvalue(),
+                gzip.decompress(m.last_request.body),
+                gzip.decompress(compressed.getvalue()),
             )
 
     def test_write_points_gzip(self):
@@ -276,9 +276,10 @@ class TestInfluxDBClient(unittest.TestCase):
                     b'cpu_load_short,host=server01,region=us-west '
                     b'value=0.64 1257894000123456000\n'
                 )
+
             self.assertEqual(
-                m.last_request.body,
-                compressed.getvalue(),
+                gzip.decompress(m.last_request.body),
+                gzip.decompress(compressed.getvalue()),
             )
 
     def test_write_points_toplevel_attributes(self):


### PR DESCRIPTION
During #852 and #853 I noticed had failures in the test suite for gzip (even though I anticipated that nothing related had been changed by me).

Turns out that gzip uses metadata during compression, here the timestamp, that is then included in the binary compressed results.
Therefore
1. gzip could be supplied with a static timestamp (possibly also filename, but that did not make a difference for my test runs with one million iterations) to have the same binary output at all times
2. the test should compare the decompressed result rather than the binary result

I chose option 2 because it avoids the tests to have an impact on the actual implementation of the client, which would have dirty and, in this case, unnecessary.