### PR TITLE
Test with 3.8 and 3.9-dev on Travis, run lints with 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
+  - "3.9-dev"
   - "pypy"
   - "pypy3"
 
@@ -23,15 +25,15 @@ addons:
 
 matrix:
   include:
-    - python: 3.7
+    - python: 3.8
       env: TOX_ENV=pep257
-    - python: 3.7
+    - python: 3.8
       env: TOX_ENV=docs
-    - python: 3.7
+    - python: 3.8
       env: TOX_ENV=flake8
-    - python: 3.7
+    - python: 3.8
       env: TOX_ENV=coverage
-    - python: 3.7
+    - python: 3.8
       env: TOX_ENV=mypy
 
 install:


### PR DESCRIPTION
---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Builds are passing
- [ ] New tests have been added (for feature additions)

3.9.0 final or anything marked 3.9 is not there yet, but 3.9-dev is 3.9.0+ at the moment.