### PR TITLE
Add the db parameter when calling the write endpoint

### DIFF
--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -411,7 +411,7 @@ class InfluxDBClient(object):
             data = ('\n'.join(data) + '\n').encode('utf-8')
 
         self.request(
-            url="write",
+            url="write?db={}".format(self._database),
             method='POST',
             params=params,
             data=data,


### PR DESCRIPTION
I'm using influxdb v1.6 on Raspberry pi3.
As writing a data points, influxdb returns an error with the message below.

```
Traceback (most recent call last):
  File "/Users/yuokada/PycharmProjects/raspberrypi-sensor-recorder/x.py", line 32, in <module>
    response = c.write(json_body, protocol='line')
  File "/Users/yuokada/PycharmProjects/raspberrypi-sensor-recorder/.venv/lib/python3.9/site-packages/influxdb/client.py", line 413, in write
    self.request(
  File "/Users/yuokada/PycharmProjects/raspberrypi-sensor-recorder/.venv/lib/python3.9/site-packages/influxdb/client.py", line 378, in request
    raise InfluxDBClientError(err_msg, response.status_code)
influxdb.exceptions.InfluxDBClientError: 400: {"error":"database is required"}
```

My simple client code is here.
```python
import influxdb.client

json_body = {
    "database": "my_collection",
    "points": [
        {
            "measurement": "tempartures",
            "tags": {
                "tag1": "raspberry-pi",
            },
            "fields": {
                "Temperature": 16.5,
                "Humidity": 51.0,
            }

        }
    ]
}

if __name__ == "__main__":
    c = influxdb.client.InfluxDBClient(host="192.168.0.1", port=8086, database="my_collection")
    assert c.ping() == '1.6.4'
    response = c.write(json_body, protocol='json')
    print(response)
```

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Builds are passing
- [ ] New tests have been added (for feature additions)
