### PR TITLE
chore: enabled syntax highlighting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,9 @@ Generated documentation can be found in the *docs/build/html/* directory.
 Examples
 --------
 
-Here's a basic example (for more see the examples directory)::
+Here's a basic example (for more see the examples directory):
+
+.. code-block:: python
 
     $ python
 


### PR DESCRIPTION
I only enabled the syntax highlighting feature for python

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Builds are passing
- [ ] New tests have been added (for feature additions)
