### PR TITLE
docs: fix simple typo, reponse -> response

### DIFF
--- a/influxdb/tests/client_test.py
+++ b/influxdb/tests/client_test.py
@@ -1398,7 +1398,7 @@ class TestInfluxDBClient(unittest.TestCase):
             InfluxDBClient('host', '80/redir', 'username', 'password')
 
     def test_chunked_response(self):
-        """Test chunked reponse for TestInfluxDBClient object."""
+        """Test chunked response for TestInfluxDBClient object."""
         example_response = \
             u'{"results":[{"statement_id":0,"series":[{"columns":["key"],' \
             '"values":[["cpu"],["memory"],["iops"],["network"]],"partial":' \


### PR DESCRIPTION
There is a small typo in influxdb/tests/client_test.py.

Should read `response` rather than `reponse`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md