### PR TITLE
Unquote username & password when parsing a DSN

### DIFF
--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -21,7 +21,7 @@ import msgpack
 import requests
 import requests.exceptions
 from requests.adapters import HTTPAdapter
-from six.moves.urllib.parse import urlparse
+from six.moves.urllib.parse import urlparse, unquote
 
 from influxdb.line_protocol import make_lines, quote_ident, quote_literal
 from influxdb.resultset import ResultSet
@@ -1247,8 +1247,8 @@ def _parse_dsn(dsn):
 
 def _parse_netloc(netloc):
     info = urlparse("http://{0}".format(netloc))
-    return {'username': info.username or None,
-            'password': info.password or None,
+    return {'username': unquote(info.username) or None,
+            'password': unquote(info.password) or None,
             'host': info.hostname or 'localhost',
             'port': info.port or 8086}
 


### PR DESCRIPTION
A DSN like: `influxdb://user:sec#ret@host:port`
should be written as `influxdb://user:sec%23ret@host:port`

RFC 3986 allows characters like # ? to appear in
username / password which should be properly unquoted

Please see relevant Python bug:
https://bugs.python.org/issue18140#msg375109
