### PR TITLE
Marshal deprecated pandas.util.testing import.

### DIFF
--- a/influxdb/tests/dataframe_client_test.py
+++ b/influxdb/tests/dataframe_client_test.py
@@ -20,7 +20,10 @@ from .client_test import _mocked_session
 
 if not using_pypy:
     import pandas as pd
-    from pandas.util.testing import assert_frame_equal
+    try:
+        from pandas.testing import assert_frame_equal
+    except ImportError:
+        from pandas.util.testing import assert_frame_equal
     from influxdb import DataFrameClient
     import numpy as np
 


### PR DESCRIPTION
Fixes warning generated by tests.

Attempts to import from pandas public API for newer versions of pandas...
`from pandas.testing import assert_frame_equal`

...resolves to the existing path when not found... 
`from pandas.util.testing import assert_frame_equal` when not found

```
FutureWarning: pandas.util.testing is deprecated. Use the functions in the public API at pandas.testing instead.
    from pandas.util.testing import assert_frame_equal
````

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Builds are passing
- [ ] New tests have been added (for feature additions)
