### PR TITLE
fix: Correctly serialize nanosecond dataframe timestamps

### DIFF
--- a/influxdb/_dataframe_client.py
+++ b/influxdb/_dataframe_client.py
@@ -372,10 +372,10 @@ class DataFrameClient(InfluxDBClient):
 
         # Make array of timestamp ints
         if isinstance(dataframe.index, pd.PeriodIndex):
-            time = ((dataframe.index.to_timestamp().values.astype(np.int64) /
+            time = ((dataframe.index.to_timestamp().values.astype(np.int64) //
                      precision_factor).astype(np.int64).astype(str))
         else:
-            time = ((pd.to_datetime(dataframe.index).values.astype(np.int64) /
+            time = ((pd.to_datetime(dataframe.index).values.astype(np.int64) //
                      precision_factor).astype(np.int64).astype(str))
 
         # If tag columns exist, make an array of formatted tag keys and values


### PR DESCRIPTION
Co-authored-by: @bednar

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Builds are passing
- [x] New tests have been added (for feature additions)
