### PR TITLE
Update docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,10 +20,15 @@ InfluxDB-Python
 
    **This project is no longer in development**
    
-   This v1 client library is for interacting with `InfluxDB 1.x <https://docs.influxdata.com/influxdb/v1/>`_ instances. 
+   This v1 client library is for interacting with `InfluxDB 1.x <https://docs.influxdata.com/influxdb/v1/>`_ and 1.x-compatible endpoints in `InfluxDB 2.x <https://docs.influxdata.com/influxdb/v2/>`_.
+   Use it to:
+   
+   - Write data in line protocol.
+   - Query data with `InfluxQL <https://docs.influxdata.com/influxdb/v1/query_language/>`_.
 
-   - If you use `InfluxDB 2.x (TSM storage engine) <https://docs.influxdata.com/influxdb/v2/>`_, see the v2 client library: https://github.com/influxdata/influxdb-client-python
-   - If you use `InfluxDB 3.0 <https://www.influxdata.com/get-influxdb/>`_, see the v3 client library, https://github.com/influxdata/influxdb3-python
+   If you use `InfluxDB 2.x (TSM storage engine) <https://docs.influxdata.com/influxdb/v2/>`_ and `Flux <https://docs.influxdata.com/flux/v0/>`_, see the `v2 client library <https://github.com/influxdata/influxdb-client-python>`_.
+
+   If you use `InfluxDB 3.0 <https://www.influxdata.com/get-influxdb/>`_, see the `v3 client library <https://github.com/influxdata/influxdb3-python>`_.
 
    For new projects, consider using InfluxDB 3.0 and v3 client libraries.
 

--- a/README.rst
+++ b/README.rst
@@ -1,14 +1,3 @@
-The v1 client libraries for InfluxDB were typically developed and maintained by
-community members. For InfluxDB 3.0 users, this library is succeeded by the
-lightweight `v3 client library <https://github.com/InfluxCommunity/influxdb3-python>`_.
-For InfluxDB 2.0 users, look at the `v2 client library
-<https://github.com/influxdata/influxdb-client-python>`_.
-
-If there are still users of this v1 client library, and they or somebody else
-are willing to keep them updated with security fixes at a minimum please reach
-out on the `Community Forums <https://community.influxdata.com/>`_ or
-`InfluxData Slack <https://influxdata.com/slack>`_.
-
 InfluxDB-Python
 ===============
 
@@ -26,38 +15,40 @@ InfluxDB-Python
    :target: https://pypi.python.org/pypi/influxdb
    :alt: PyPI Status
 
-InfluxDB-Python is a client for interacting with InfluxDB_.
 
-**Note: This library is for use with InfluxDB 1.x. For connecting to InfluxDB 2.x instances, please use the the** `influxdb-client-python <https://github.com/influxdata/influxdb-client-python>`_ **client.**
+.. important::
 
-Development of this library is maintained by:
+   **This project is no longer in development**
+   
+   This v1 client library is for interacting with `InfluxDB 1.x <https://docs.influxdata.com/influxdb/v1/>`_ instances. 
 
-+-----------+-------------------------------+
-| Github ID | URL                           |
-+===========+===============================+
-| @aviau    | (https://github.com/aviau)    |
-+-----------+-------------------------------+
-| @xginn8   | (https://github.com/xginn8)   |
-+-----------+-------------------------------+
-| @sebito91 | (https://github.com/sebito91) |
-+-----------+-------------------------------+
+   - If you use `InfluxDB 2.x (TSM storage engine) <https://docs.influxdata.com/influxdb/v2/>`_, see the v2 client library: https://github.com/influxdata/influxdb-client-python
+   - If you use `InfluxDB 3.0 <https://www.influxdata.com/get-influxdb/>`_, see the v3 client library, https://github.com/influxdata/influxdb3-python
+
+   For new projects, consider using InfluxDB 3.0 and v3 client libraries.
+
+Description
+===========
+
+InfluxDB-python, the InfluxDB Python Client (1.x), is a client library for interacting with `InfluxDB 1.x <https://docs.influxdata.com/influxdb/v1/>`_ instances.
 
 .. _readme-about:
 
-InfluxDB is an open-source distributed time series database, find more about InfluxDB_ at https://docs.influxdata.com/influxdb/latest
+`InfluxDB`_ is the time series platform designed to handle high write and query loads.
 
 
 .. _installation:
 
-InfluxDB pre v1.1.0 users
--------------------------
 
-This module is tested with InfluxDB versions: v1.2.4, v1.3.9, v1.4.3, v1.5.4, v1.6.4, and 1.7.4.
+For InfluxDB pre-v1.1.0 users
+-----------------------------
 
-Those users still on InfluxDB v0.8.x users may still use the legacy client by importing ``from influxdb.influxdb08 import InfluxDBClient``.
+This module is tested with InfluxDB versions v1.2.4, v1.3.9, v1.4.3, v1.5.4, v1.6.4, and 1.7.4.
 
-Installation
-------------
+Users on InfluxDB v0.8.x may still use the legacy client by importing ``from influxdb.influxdb08 import InfluxDBClient``.
+
+For InfluxDB v1.1+ users
+------------------------
 
 Install, upgrade and uninstall influxdb-python with these commands::
 
@@ -165,21 +156,33 @@ We are also lurking on the following:
 Development
 -----------
 
+The v1 client libraries for InfluxDB 1.x were typically developed and maintained by InfluxDB community members. If you are an InfluxDB v1 user interested in maintaining this client library (at a minimum, keeping it updated with security patches) please contact the InfluxDB team at on the `Community Forums <https://community.influxdata.com/>`_ or
+`InfluxData Slack <https://influxdata.com/slack>`_.
+
 All development is done on Github_. Use Issues_ to report
 problems or submit contributions.
 
 .. _Github: https://github.com/influxdb/influxdb-python/
 .. _Issues: https://github.com/influxdb/influxdb-python/issues
 
-Please note that we WILL get to your questions/issues/concerns as quickly as possible. We maintain many
-software repositories and sometimes things may get pushed to the backburner. Please don't take offense,
-we will do our best to reply as soon as possible!
+Please note that we will answer you question as quickly as possible.
 
+Maintainers:
+
++-----------+-------------------------------+
+| Github ID | URL                           |
++===========+===============================+
+| @aviau    | (https://github.com/aviau)    |
++-----------+-------------------------------+
+| @xginn8   | (https://github.com/xginn8)   |
++-----------+-------------------------------+
+| @sebito91 | (https://github.com/sebito91) |
++-----------+-------------------------------+
 
 Source code
 -----------
 
-The source code is currently available on Github: https://github.com/influxdata/influxdb-python
+The source code for the InfluxDB Python Client (1.x) is currently available on Github: https://github.com/influxdata/influxdb-python
 
 
 TODO
@@ -188,6 +191,6 @@ TODO
 The TODO/Roadmap can be found in Github bug tracker: https://github.com/influxdata/influxdb-python/issues
 
 
-.. _InfluxDB: https://influxdata.com/time-series-platform/influxdb/
+.. _InfluxDB: https://influxdata.com/
 .. _Sphinx: http://sphinx.pocoo.org/
 .. _Tox: https://tox.readthedocs.org

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -117,7 +117,8 @@ html_theme = "sphinx_rtd_theme"
 
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+# Calling get_html_theme_path is deprecated.
+# html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -33,7 +33,7 @@ Tutorials - UDP
    :language: python
 
 Tutorials - Authorization by Token
-===============
+==================================
 
 .. literalinclude:: ../../examples/tutorial_authorization.py
    :language: python

--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -395,7 +395,7 @@ class InfluxDBClient(object):
         :param data: the data to be written
         :type data: (if protocol is 'json') dict
                     (if protocol is 'line') sequence of line protocol strings
-                                            or single string
+                    or single string
         :param params: additional parameters for the request, defaults to None
         :type params: dict
         :param expected_response_code: the expected response code of the write
@@ -571,8 +571,9 @@ class InfluxDBClient(object):
         :param points: the list of points to be written in the database
         :type points: list of dictionaries, each dictionary represents a point
         :type points: (if protocol is 'json') list of dicts, where each dict
-                                            represents a point.
-                    (if protocol is 'line') sequence of line protocol strings.
+                      represents a point.
+                      (if protocol is 'line') sequence of line protocol strings.
+
         :param time_precision: Either 's', 'm', 'ms' or 'u', defaults to None
         :type time_precision: str
         :param database: the database to write the points to. Defaults to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-dateutil>=2.6.0
-pytz
+pytz>=2016.10
 requests>=2.17.0
 six>=1.10.0
-msgpack
+msgpack>=0.5.0

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,11 @@ with open(os.path.join(os.path.dirname(__file__), 'influxdb', '__init__.py')) as
 with open('requirements.txt', 'r') as f:
     requires = [x.strip() for x in f if x.strip()]
 
+# Debugging: Print the requires values
+print("install_requires values:")
+for req in requires:
+    print(f"- {req}")
+
 with open('test-requirements.txt', 'r') as f:
     test_requires = [x.strip() for x in f if x.strip()]
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,8 +12,8 @@ deps = -r{toxinidir}/requirements.txt
        py35: numpy==1.14.6
        py36: pandas==0.23.4
        py36: numpy==1.15.4
-       py37: pandas==0.24.2
-       py37: numpy==1.16.2
+       py37: pandas>=0.24.2
+       py37: numpy>=1.16.2
 # Only install pandas with non-pypy interpreters
 # Testing all combinations would be too expensive
 commands = nosetests -v --with-doctest {posargs}
@@ -38,9 +38,9 @@ commands = nosetests -v --with-coverage --cover-html --cover-package=influxdb
 
 [testenv:docs]
 deps = -r{toxinidir}/requirements.txt
-       pandas==0.24.2
-       numpy==1.16.2
-       Sphinx==1.8.5
+       pandas>=0.24.2
+       numpy>=1.16.2
+       Sphinx>=1.8.5
        sphinx_rtd_theme
 commands = sphinx-build -b html docs/source docs/build
 


### PR DESCRIPTION
- Updates the version advice and removes the succession statement to be consistent with the OSS 1.11 release.
- Adds explicit relations to v2 and v3.
- Removes redundancies.
- Fixes formatting errors reported by the linter.
- Updates dependencies for docs build.

Fixed and tested docs generation for Readthedocs (Sphinx):

![image](https://github.com/user-attachments/assets/613bb612-1a7c-4978-ba89-2c8c47c24a10)

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Builds are passing



